### PR TITLE
fix: restore package publishing metadata

### DIFF
--- a/packages/astropress-mcp/package.json
+++ b/packages/astropress-mcp/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "prepublishOnly": "bun run build",
     "start": "node dist/server.js"
   },
   "dependencies": {
@@ -25,5 +26,12 @@
     "node": ">=24.8.0"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Astropress/astropress"
+  },
+  "bugs": {
+    "url": "https://github.com/Astropress/astropress/issues"
+  },
   "homepage": "https://astropress.diy"
 }

--- a/packages/astropress-nexus/package.json
+++ b/packages/astropress-nexus/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "prepublishOnly": "bun run build",
     "start": "node dist/server.js",
     "dev": "bun run src/server.ts",
     "test": "bunx vitest run"
@@ -32,5 +33,12 @@
     "node": ">=24.8.0"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Astropress/astropress"
+  },
+  "bugs": {
+    "url": "https://github.com/Astropress/astropress/issues"
+  },
   "homepage": "https://astropress.diy"
 }

--- a/packages/astropress-nexus/src/server.ts
+++ b/packages/astropress-nexus/src/server.ts
@@ -1,12 +1,13 @@
 import { serve } from "@hono/node-server";
 import { createNexusApp } from "./app.js";
 import { loadConfigFromFile } from "./registry.js";
+import type { NexusConfig } from "./types.js";
 
 const configPath = process.env.NEXUS_CONFIG ?? "nexus.config.json";
 const authToken = process.env.NEXUS_AUTH_TOKEN;
 const port = Number(process.env.PORT ?? 4330);
 
-let config;
+let config: NexusConfig;
 try {
   config = loadConfigFromFile(configPath);
 } catch (err) {

--- a/packages/astropress-nexus/tsconfig.json
+++ b/packages/astropress-nexus/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/packages/astropress/package.json
+++ b/packages/astropress/package.json
@@ -483,10 +483,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/astropress/astropress"
+    "url": "https://github.com/Astropress/astropress"
   },
   "bugs": {
-    "url": "https://github.com/astropress/astropress/issues"
+    "url": "https://github.com/Astropress/astropress/issues"
   },
   "homepage": "https://astropress.diy",
   "engines": {


### PR DESCRIPTION
## Summary

- normalize package repository metadata for npm trusted publishing
- ensure MCP and Nexus build before publish
- fix Nexus build typing so dist/server.js is present during publish

## Testing

- cd packages/astropress-mcp && bun run build
- cd packages/astropress-nexus && bun run build