### PR TITLE
fix(release): wire crates.io and npm publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "cli-v*"
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       id-token: write  # required for npm trusted publishing (OIDC)
@@ -46,7 +47,7 @@ jobs:
           # Each package (astropress, astropress-mcp, astropress-nexus) must be
           # registered as a trusted publisher on npmjs.com before this works.
 
-      - name: Tag CLI release if version not yet tagged
+      - name: Tag and dispatch CLI release
         if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,9 +55,12 @@ jobs:
           VERSION=$(grep '^version' crates/astropress-cli/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           TAG="cli-v${VERSION}"
           if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}"; then
-            echo "Tag ${TAG} already exists — skipping CLI release"
+            echo "Tag ${TAG} already exists"
           else
             git tag "${TAG}"
             git push origin "${TAG}"
-            echo "Pushed ${TAG} — cli-release.yml will build and publish"
+            echo "Pushed ${TAG}"
           fi
+
+          gh workflow run cli-release.yml --ref "${TAG}"
+          echo "Dispatched cli-release.yml for ${TAG}"

--- a/packages/astropress-mcp/package.json
+++ b/packages/astropress-mcp/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "prepublishOnly": "bun run build",
     "start": "node dist/server.js"
   },
   "dependencies": {
@@ -25,5 +26,12 @@
     "node": ">=24.8.0"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Astropress/astropress"
+  },
+  "bugs": {
+    "url": "https://github.com/Astropress/astropress/issues"
+  },
   "homepage": "https://astropress.diy"
 }

--- a/packages/astropress-nexus/package.json
+++ b/packages/astropress-nexus/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "prepublishOnly": "bun run build",
     "start": "node dist/server.js",
     "dev": "bun run src/server.ts",
     "test": "bunx vitest run"
@@ -32,5 +33,12 @@
     "node": ">=24.8.0"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Astropress/astropress"
+  },
+  "bugs": {
+    "url": "https://github.com/Astropress/astropress/issues"
+  },
   "homepage": "https://astropress.diy"
 }

--- a/packages/astropress-nexus/src/server.ts
+++ b/packages/astropress-nexus/src/server.ts
@@ -1,12 +1,13 @@
 import { serve } from "@hono/node-server";
 import { createNexusApp } from "./app.js";
 import { loadConfigFromFile } from "./registry.js";
+import type { NexusConfig } from "./types.js";
 
 const configPath = process.env.NEXUS_CONFIG ?? "nexus.config.json";
 const authToken = process.env.NEXUS_AUTH_TOKEN;
 const port = Number(process.env.PORT ?? 4330);
 
-let config;
+let config: NexusConfig;
 try {
   config = loadConfigFromFile(configPath);
 } catch (err) {

--- a/packages/astropress-nexus/tsconfig.json
+++ b/packages/astropress-nexus/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/packages/astropress/package.json
+++ b/packages/astropress/package.json
@@ -483,10 +483,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/astropress/astropress"
+    "url": "https://github.com/Astropress/astropress"
   },
   "bugs": {
-    "url": "https://github.com/astropress/astropress/issues"
+    "url": "https://github.com/Astropress/astropress/issues"
   },
   "homepage": "https://astropress.diy",
   "engines": {


### PR DESCRIPTION
## Summary

- Switches crates.io publish from `CARGO_REGISTRY_TOKEN` secret to OIDC trusted publishing (`rust-lang/crates-io-auth-action@v1`), removing the secret dependency
- Adds the missing `actions: write` permission and tag+dispatch step to `release.yml` so the CLI `cli-v*` tag is created and `cli-release.yml` is dispatched automatically after npm packages publish
- Adds `workflow_dispatch` trigger to `cli-release.yml` so it can be dispatched programmatically and tested manually
- Corrects scoped package names (`astropress-mcp` → `@astropress-diy/mcp`, `astropress-nexus` → `@astropress-diy/nexus`) and adds missing `prepublishOnly` build scripts
- Removes broken `-- --provenance` CLI flag (npm provenance is handled automatically via the `id-token: write` OIDC permission)
- Upgrades stale action versions across workflows (checkout@v6, upload-artifact@v7, download-artifact@v8, action-gh-release@v3)

## Test plan

- [ ] Merge to main and verify changesets publishes npm packages successfully
- [ ] Verify `Tag and dispatch CLI release` step runs after publish and pushes a `cli-v*` tag
- [ ] Verify `cli-release.yml` triggers, builds binaries across all targets, creates GitHub release, and publishes `astropress-cli` to crates.io
- [ ] Confirm crates.io trusted publisher is configured for `astropress-cli` under the repo (prerequisite for OIDC to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)