### PR TITLE
fix(cli-release): use workspace target dir

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Rename binary (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-          mv target/${{ matrix.target }}/release/astropress ${{ matrix.artifact }}
+          mv crates/target/${{ matrix.target }}/release/astropress ${{ matrix.artifact }}
           chmod +x ${{ matrix.artifact }}
 
       - name: Rename binary (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
-        run: Move-Item target\${{ matrix.target }}\release\astropress.exe ${{ matrix.artifact }}
+        run: Move-Item crates\target\${{ matrix.target }}\release\astropress.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary\n- point CLI release artifact renames at the Cargo workspace target directory\n- unblock GitHub release artifact upload and crates.io publish for cli-v0.0.2\n\n## Testing\n- pre-push gates\n- manually triggered CLI Release showed the old target path failure