### PR TITLE
fix(cli-release): use actual binary name

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Rename binary (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-          mv crates/target/${{ matrix.target }}/release/astropress ${{ matrix.artifact }}
+          mv crates/target/${{ matrix.target }}/release/astropress-cli ${{ matrix.artifact }}
           chmod +x ${{ matrix.artifact }}
 
       - name: Rename binary (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
-        run: Move-Item crates\target\${{ matrix.target }}\release\astropress.exe ${{ matrix.artifact }}
+        run: Move-Item crates\target\${{ matrix.target }}\release\astropress-cli.exe ${{ matrix.artifact }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary\n- rename the packaged CLI binary from its real Cargo output name\n- unblock artifact upload, GitHub release creation, and crates.io publish\n\n## Testing\n- cargo build --release --manifest-path crates/astropress-cli/Cargo.toml\n- pre-push gates\n- failed CLI Release run 24463855224 showed the rename step still used the wrong binary name