### PR TITLE
fix(release): publish crate from trusted workflow

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -86,22 +86,3 @@ jobs:
         with:
           files: artifacts/*
           generate_release_notes: true
-
-  publish-crate:
-    name: Publish to crates.io
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # required for crates.io trusted publishing (OIDC)
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: rust-lang/crates-io-auth-action@v1
-        # Exchanges the GitHub OIDC token for a short-lived crates.io token
-        # and sets CARGO_REGISTRY_TOKEN automatically. No secret needed.
-        # astropress-cli must be registered as a trusted publisher on crates.io first.
-
-      - name: Publish astropress-cli
-        run: cargo publish --manifest-path crates/astropress-cli/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -11,6 +12,8 @@ jobs:
   release:
     name: Publish to npm
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     permissions:
       actions: write
       contents: write
@@ -64,3 +67,20 @@ jobs:
 
           gh workflow run cli-release.yml --ref "${TAG}"
           echo "Dispatched cli-release.yml for ${TAG}"
+
+  publish-cli-crate:
+    name: Publish CLI crate
+    needs: release
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.release.outputs.published == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish astropress-cli
+        run: cargo publish --manifest-path crates/astropress-cli/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
           # GitHub API commits are GitHub-signed and avoid local hook failures
           # on the runner when Changesets creates the version PR commit.
           commitMode: github-api
+          # npm is the install path for these packages; GitHub release UI entries
+          # add no user value. Git tags are still created for traceability.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # No NPM_TOKEN — npm uses the OIDC token from id-token: write above.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Use `astropress list tools` and `astropress list providers` for the CLI view. Th
 |---|---|---|
 | **App hosts** | GitHub Pages, Cloudflare Pages, Vercel, Netlify, Render Static, Render Web, GitLab Pages, Fly.io, Coolify, DigitalOcean App Platform, Railway | Static deploys, server-backed deploys, or self-hosted/container deploy paths generated into `DEPLOY.md` and scaffold CI files |
 | **Content/data services** | Built-in SQLite, Cloudflare D1 + R2, Supabase, Neon, Nhost, PocketBase, Appwrite, Turso, custom adapter | Keep Astropress content local, move it to a hosted service, or wire in a custom runtime adapter without changing the admin surface |
-| **Import sources** | WordPress XML, Wix export/crawl | Stage migrations into reviewable artifacts before applying them locally |
+| **Import sources** | WordPress XML, Wix export/crawl, Mailchimp subscriber lists | Stage migrations into reviewable artifacts before applying them locally |
+| **Multisite** | [Astropress Nexus](./packages/astropress-nexus/) | A single control plane over multiple Astropress sites — shared auth, cross-site search, and a unified admin gateway |
 | **Docs sites** | Starlight, VitePress, mdBook | Generate a docs area alongside the site with a matching scaffold and docs-specific build scripts |
 | **Analytics** | Umami, Plausible, Matomo, PostHog, custom | Add privacy-first analytics, dashboards, and optional replay/heatmap support |
 | **A/B testing and flags** | GrowthBook, Unleash, Flagsmith, custom | Feature flags, experiments, and release controls from the same project scaffold |


### PR DESCRIPTION
## Summary 

- move crates.io publishing from cli-release.yml to release.yml
- align the OIDC workflow filename with the crates.io trusted publisher config
- keep cli-release.yml focused on binary builds and GitHub release assets

## Testing

- pre-push gates
- failed run 24464544851 proved binaries/release are fixed and only crates.io workflow filename remained mismatched