### PR TITLE
Tighten origin checks for invite and reset POSTs

### DIFF
--- a/packages/astropress/index.ts
+++ b/packages/astropress/index.ts
@@ -263,6 +263,7 @@ export {
   createAstropressSecureRedirect,
   createAstropressSecurityHeaders,
   isTrustedRequestOrigin,
+  isTrustedStrictRequestOrigin,
 } from "./src/security-headers.js";
 export type { AstropressSecurityArea, AstropressSecurityHeadersOptions } from "./src/security-headers";
 export { createAstropressSecurityMiddleware, resolveAstropressSecurityArea } from "./src/security-middleware.js";

--- a/packages/astropress/pages/ap-admin/actions/accept-invite.ts
+++ b/packages/astropress/pages/ap-admin/actions/accept-invite.ts
@@ -1,8 +1,12 @@
 import type { APIRoute } from "astro";
-import { consumeRuntimeInviteToken, createAstropressSecureRedirect, isTrustedRequestOrigin } from "@astropress-diy/astropress";
+import {
+  consumeRuntimeInviteToken,
+  createAstropressSecureRedirect,
+  isTrustedStrictRequestOrigin,
+} from "@astropress-diy/astropress";
 
 export const POST: APIRoute = async ({ request, locals }) => {
-  if (!isTrustedRequestOrigin(request)) {
+  if (!isTrustedStrictRequestOrigin(request)) {
     return createAstropressSecureRedirect("/ap-admin/accept-invite?error=1&message=Invalid+request+origin", 302, {
       forceHsts: request.url.startsWith("https://"),
     });

--- a/packages/astropress/pages/ap-admin/actions/reset-password.ts
+++ b/packages/astropress/pages/ap-admin/actions/reset-password.ts
@@ -3,12 +3,12 @@ import {
   consumeRuntimePasswordResetToken,
   createAstropressSecureRedirect,
   createRuntimePasswordResetToken,
-  isTrustedRequestOrigin,
+  isTrustedStrictRequestOrigin,
 } from "@astropress-diy/astropress";
 import { sendPasswordResetEmail } from "@astropress-diy/astropress";
 
 export const POST: APIRoute = async ({ request, locals }) => {
-  if (!isTrustedRequestOrigin(request)) {
+  if (!isTrustedStrictRequestOrigin(request)) {
     return createAstropressSecureRedirect("/ap-admin/reset-password?error=1&message=Invalid+request+origin", 302, {
       forceHsts: request.url.startsWith("https://"),
     });

--- a/packages/astropress/src/security-headers.ts
+++ b/packages/astropress/src/security-headers.ts
@@ -143,3 +143,22 @@ export function isTrustedRequestOrigin(request: Request): boolean {
 
   return true;
 }
+
+export function isTrustedStrictRequestOrigin(request: Request): boolean {
+  const requestUrl = parseOrigin(request.url);
+  if (!requestUrl) {
+    return false;
+  }
+
+  const origin = parseOrigin(request.headers.get("origin"));
+  if (origin) {
+    return origin.origin === requestUrl.origin;
+  }
+
+  const referer = parseOrigin(request.headers.get("referer"));
+  if (referer) {
+    return referer.origin === requestUrl.origin;
+  }
+
+  return false;
+}

--- a/packages/astropress/tests/security-headers.test.ts
+++ b/packages/astropress/tests/security-headers.test.ts
@@ -6,6 +6,7 @@ import {
   createAstropressSecureRedirect,
   createAstropressSecurityHeaders,
   isTrustedRequestOrigin,
+  isTrustedStrictRequestOrigin,
 } from "../src/security-headers.js";
 import { resolveAstropressSecurityArea } from "../src/security-middleware.js";
 
@@ -135,6 +136,25 @@ describe("security headers", () => {
         }),
       ),
     ).toBe(true); // parseOrigin throws → null → falls through to referer → no referer → return true
+  });
+
+  it("strict origin checks reject requests with no origin or referer headers", () => {
+    expect(
+      isTrustedStrictRequestOrigin(
+        new Request("https://example.com/ap-admin/save", {
+          method: "POST",
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      isTrustedStrictRequestOrigin(
+        new Request("https://example.com/ap-admin/save", {
+          method: "POST",
+          headers: { origin: "https://example.com" },
+        }),
+      ),
+    ).toBe(true);
   });
 
   it("uses SAMEORIGIN when frameAncestors option is not 'none'", () => {


### PR DESCRIPTION
Fixes #36.

- adds `isTrustedStrictRequestOrigin()` for POST auth entrypoints that must fail closed when `Origin` and `Referer` are both absent
- switches invite acceptance and password reset actions to the strict check
- re-exports the helper from the package root
- adds focused coverage for the new behavior

Validation:
- `bun run test tests/security-headers.test.ts` passed
- full suite surfaced an unrelated deploy-targets test flake, tracked separately in #44
