### PR TITLE
Harden echoed admin links on auth pages

### DIFF
--- a/packages/astropress/pages/ap-admin/reset-password.astro
+++ b/packages/astropress/pages/ap-admin/reset-password.astro
@@ -1,9 +1,10 @@
 ---
 import { buildAstropressAdminDocumentTitle, buildResetPasswordPageModel, resolveAstropressAdminUiConfig } from "astropress";
+import { resolveSafeAdminHref } from "../../src/admin-link-utils";
 
 const token = Astro.url.searchParams.get("token") ?? "";
 const mailSent = Astro.url.searchParams.get("mail_sent") === "1";
-const resetLink = Astro.url.searchParams.get("reset_link");
+const resetLink = resolveSafeAdminHref(Astro.url, Astro.url.searchParams.get("reset_link"), ["/ap-admin/reset-password"]);
 const hasError = Astro.url.searchParams.get("error") === "1";
 const errorMessage = Astro.url.searchParams.get("message") ?? "That password reset link is invalid or has expired.";
 const model = await buildResetPasswordPageModel(Astro.locals, token);

--- a/packages/astropress/pages/ap-admin/users.astro
+++ b/packages/astropress/pages/ap-admin/users.astro
@@ -3,6 +3,7 @@ import AdminLayout from "@astropress-diy/astropress/components/AdminLayout.astro
 import AuditTrail from "@astropress-diy/astropress/components/AuditTrail.astro";
 import CsrfInput from "@astropress-diy/astropress/components/CsrfInput.astro";
 import { buildUsersPageModel } from "astropress";
+import { resolveSafeAdminHref } from "../../src/admin-link-utils";
 
 const adminUser = Astro.locals.adminUser;
 const model = await buildUsersPageModel(Astro.locals, adminUser!.role);
@@ -11,8 +12,8 @@ const wasCreated = Astro.url.searchParams.get("saved") === "1";
 const userCreatedNoEmail = Astro.url.searchParams.get("user_created") === "1";
 const wasSuspended = Astro.url.searchParams.get("suspended") === "1";
 const wasRestored = Astro.url.searchParams.get("restored") === "1";
-const inviteLink = Astro.url.searchParams.get("invite_link");
-const resetLink = Astro.url.searchParams.get("reset_link");
+const inviteLink = resolveSafeAdminHref(Astro.url, Astro.url.searchParams.get("invite_link"), ["/ap-admin/accept-invite"]);
+const resetLink = resolveSafeAdminHref(Astro.url, Astro.url.searchParams.get("reset_link"), ["/ap-admin/reset-password"]);
 const errorMessage = Astro.url.searchParams.get("error") === "1" ? Astro.url.searchParams.get("message") : "";
 
 if (model.status === "forbidden") {

--- a/packages/astropress/src/admin-link-utils.ts
+++ b/packages/astropress/src/admin-link-utils.ts
@@ -1,0 +1,29 @@
+function parseUrl(value: string | null | undefined, baseUrl: URL): URL | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed, baseUrl);
+  } catch {
+    return null;
+  }
+}
+
+export function resolveSafeAdminHref(baseUrl: URL, value: string | null | undefined, allowedPaths: string[]): string | null {
+  const parsed = parseUrl(value, baseUrl);
+  if (!parsed || parsed.origin !== baseUrl.origin) {
+    return null;
+  }
+
+  if (!allowedPaths.includes(parsed.pathname)) {
+    return null;
+  }
+
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+}

--- a/packages/astropress/tests/admin-link-utils.test.ts
+++ b/packages/astropress/tests/admin-link-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveSafeAdminHref } from "../src/admin-link-utils.js";
+
+describe("resolveSafeAdminHref", () => {
+  const baseUrl = new URL("https://example.com/ap-admin/users");
+
+  it("returns null for missing or blank values", () => {
+    expect(resolveSafeAdminHref(baseUrl, null, ["/ap-admin/accept-invite"])).toBeNull();
+    expect(resolveSafeAdminHref(baseUrl, "", ["/ap-admin/accept-invite"])).toBeNull();
+    expect(resolveSafeAdminHref(baseUrl, "   ", ["/ap-admin/accept-invite"])).toBeNull();
+  });
+
+  it("returns same-origin allowlisted paths as relative hrefs", () => {
+    expect(resolveSafeAdminHref(baseUrl, "/ap-admin/accept-invite?token=abc", ["/ap-admin/accept-invite"])).toBe(
+      "/ap-admin/accept-invite?token=abc",
+    );
+  });
+
+  it("returns same-origin allowlisted paths as absolute hrefs", () => {
+    expect(
+      resolveSafeAdminHref(baseUrl, "https://example.com/ap-admin/reset-password?token=xyz", [
+        "/ap-admin/reset-password",
+      ]),
+    ).toBe("/ap-admin/reset-password?token=xyz");
+  });
+
+  it("rejects off-origin and non-allowlisted values", () => {
+    expect(resolveSafeAdminHref(baseUrl, "https://evil.example/ap-admin/accept-invite?token=abc", [
+      "/ap-admin/accept-invite",
+    ])).toBeNull();
+    expect(resolveSafeAdminHref(baseUrl, "/ap-admin/other?token=abc", ["/ap-admin/accept-invite"])).toBeNull();
+    expect(resolveSafeAdminHref(baseUrl, "javascript:alert(1)", ["/ap-admin/accept-invite"])).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #38.

This PR stops the admin users and reset-password pages from echoing arbitrary query-string URLs back into clickable links.

What changed:
- added resolveSafeAdminHref() in packages/astropress/src/admin-link-utils.ts
- allowlisted only the intended admin paths for invite/reset links
- rejected blank, cross-origin, and javascript: values
- covered the helper with focused unit tests

Why this matters:
- these pages render URLs sourced from search params
- without validation, a malicious URL could be surfaced as a trusted-looking admin link
- the new helper keeps the UI usable for legitimate same-origin links while failing closed for unsafe input

Validation:
- bun run test tests/admin-link-utils.test.ts tests/security-headers.test.ts passed
- bun run build passed in packages/astropress
- full bun run test passed through all relevant auth/security flows, but still hits unrelated flaky failures tracked in #42:
  - tests/sqlite-admin-runtime-auth.test.ts
  - tests/web-components/theme-toggle.test.ts

Review notes:
- the branch is isolated to the two admin pages plus the new helper and test file
- I did not find spillover changes from the issue-35 or issue-36 branches