### PR TITLE
chore(deps): batch dependabot — astro 6.1.9 + actions v7/v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           path: packages/astropress/dist
           key: astropress-dist-${{ steps.skip.outputs.hash }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: astropress-dist
           path: packages/astropress/dist
@@ -210,7 +210,7 @@ jobs:
 
       - run: bun install --frozen-lockfile
         if: steps.skip.outputs.cache-hit != 'true'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.skip.outputs.cache-hit != 'true'
         with:
           name: astropress-dist
@@ -300,7 +300,7 @@ jobs:
 
       - run: bun install --frozen-lockfile
         if: steps.skip.outputs.cache-hit != 'true'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.skip.outputs.cache-hit != 'true'
         with:
           name: astropress-dist
@@ -341,7 +341,7 @@ jobs:
 
       - run: bun install --frozen-lockfile
         if: steps.skip.outputs.cache-hit != 'true'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.skip.outputs.cache-hit != 'true'
         with:
           name: astropress-dist
@@ -384,7 +384,7 @@ jobs:
 
       - run: bun install
         if: steps.skip.outputs.cache-hit != 'true'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.skip.outputs.cache-hit != 'true'
         with:
           name: astropress-dist
@@ -474,7 +474,7 @@ jobs:
 
       - run: bun install --frozen-lockfile
         if: steps.skip.outputs.cache-hit != 'true'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.skip.outputs.cache-hit != 'true'
         with:
           name: astropress-dist
@@ -533,7 +533,7 @@ jobs:
 
       - run: bun install --frozen-lockfile
         if: steps.skip.outputs.cache-hit != 'true'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: steps.skip.outputs.cache-hit != 'true'
         with:
           name: astropress-dist
@@ -578,7 +578,7 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
           restore-keys: ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: astropress-dist
           path: packages/astropress/dist

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -76,7 +76,7 @@ jobs:
         run: npx stryker run ../../tooling/stryker/stryker-critical.config.mjs
         working-directory: packages/astropress
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: stryker-report
@@ -97,7 +97,7 @@ jobs:
         run: cargo mutants --package astropress-cli --timeout 60
         working-directory: crates
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cargo-mutants-report

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "astropress-monorepo",
       "dependencies": {
         "@astrojs/starlight": "^0.38.4",
-        "astro": "^6.1.8",
+        "astro": "^6.1.9",
         "sanitize-html": "^2.17.3",
         "vitest": "^4.1.5",
       },
@@ -34,7 +34,7 @@
       "name": "astropress-example-admin-harness",
       "dependencies": {
         "@astropress-diy/astropress": "workspace:*",
-        "astro": "6.1.8",
+        "astro": "6.1.9",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -46,7 +46,7 @@
       "name": "astropress-example-gh-pages",
       "dependencies": {
         "@astropress-diy/astropress": "workspace:*",
-        "astro": "6.1.8",
+        "astro": "6.1.9",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -59,7 +59,7 @@
       "name": "astropress-example-npm-consumer-smoke",
       "dependencies": {
         "@astropress-diy/astropress": "workspace:*",
-        "astro": "6.1.8",
+        "astro": "6.1.9",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -125,7 +125,7 @@
       "name": "astropress-docs",
       "dependencies": {
         "@astrojs/starlight": "^0.38.3",
-        "astro": "^6.1.8",
+        "astro": "^6.1.9",
         "sharp": "^0.34.5",
       },
       "devDependencies": {
@@ -136,7 +136,7 @@
     },
   },
   "overrides": {
-    "astro": "^6.1.8",
+    "astro": "^6.1.9",
     "hono": "^4.12.14",
     "postcss": "^8.5.10",
     "vite": "^7.3.2",
@@ -155,7 +155,7 @@
 
     "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.8.0", "", { "dependencies": { "picomatch": "^4.0.3" } }, "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
 
     "@astrojs/language-server": ["@astrojs/language-server@2.16.6", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.3", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.15", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug=="],
 
@@ -733,7 +733,7 @@
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
-    "astro": ["astro@6.1.8", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.8.0", "@astrojs/markdown-remark": "7.1.0", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^7.3.1", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-6fT9M12U3fpi13DiPavNKDIoBflASTSxmKTEe+zXhWtlebQuOqfOnIrMWyRmlXp+mgDsojmw+fVFG9LUTzKSog=="],
+    "astro": ["astro@6.1.9", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.9.0", "@astrojs/markdown-remark": "7.1.1", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ=="],
 
     "astro-expressive-code": ["astro-expressive-code@0.41.7", "", { "dependencies": { "rehype-expressive-code": "^0.41.7" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ=="],
 
@@ -1915,6 +1915,8 @@
 
     "@astrojs/language-server/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
 
+    "@astrojs/markdown-remark/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.8.0", "", { "dependencies": { "picomatch": "^4.0.3" } }, "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w=="],
+
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1952,6 +1954,8 @@
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "astro/@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA=="],
 
     "cross-spawn/path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 

--- a/examples/admin-harness/package.json
+++ b/examples/admin-harness/package.json
@@ -8,7 +8,7 @@
 		"check": "astro check"
 	},
 	"dependencies": {
-		"astro": "6.1.8",
+		"astro": "6.1.9",
 		"@astropress-diy/astropress": "workspace:*"
 	},
 	"devDependencies": {

--- a/examples/github-pages/package.json
+++ b/examples/github-pages/package.json
@@ -13,7 +13,7 @@
 		"prepare": "bunx lefthook install"
 	},
 	"dependencies": {
-		"astro": "6.1.8",
+		"astro": "6.1.9",
 		"@astropress-diy/astropress": "workspace:*"
 	},
 	"devDependencies": {

--- a/examples/npm-consumer-smoke/package.json
+++ b/examples/npm-consumer-smoke/package.json
@@ -8,7 +8,7 @@
 		"check": "astro check"
 	},
 	"dependencies": {
-		"astro": "6.1.8",
+		"astro": "6.1.9",
 		"@astropress-diy/astropress": "workspace:*"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
 	"overrides": {
 		"yaml": "^2.8.3",
 		"vite": "^7.3.2",
-		"astro": "^6.1.8",
+		"astro": "^6.1.9",
 		"hono": "^4.12.14",
 		"postcss": "^8.5.10"
 	},
@@ -137,7 +137,7 @@
 	},
 	"dependencies": {
 		"@astrojs/starlight": "^0.38.4",
-		"astro": "^6.1.8",
+		"astro": "^6.1.9",
 		"sanitize-html": "^2.17.3",
 		"vitest": "^4.1.5"
 	}

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"@astrojs/starlight": "^0.38.3",
-		"astro": "^6.1.8",
+		"astro": "^6.1.9",
 		"sharp": "^0.34.5"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary
- Bumps astro from 6.1.8 to 6.1.9 (group: astro) — dependabot #66
- Bumps actions/upload-artifact v4→v7 and actions/download-artifact v4→v8 (group: actions-all) — dependabot #67
- Refreshes bun.lock to match the new astro version

## Why bundle them
Two open dependabot PRs targeting independent surfaces (workspace dep + CI action). One PR runs the full pre-push gate suite once instead of twice.

## Verification
- Local pre-push gate suite: green (slow-audits 19s; gates 12.7s; signed-commits, mutation-gate, sweep-tmp all pass)
- astro-docs check: 0 errors / 0 warnings / 0 hints after content store re-sync
- Workflow input usage (`name`, `path` only) is stable across upload-artifact v4→v7 and download-artifact v4→v8 — no input-schema changes required

## Test plan
- [ ] CI green on this PR (canonical signal that the v7/v8 action bumps work end-to-end with our artifact paths)
- [ ] CodeQL/GHAS scan on PR merge ref shows 0 alerts
- [ ] Closes dependabot PRs #66 and #67

Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)