### PR TITLE
fix(ci)+feat(integrations): unblock mutation CI, batch dep bumps, seal OAuth callback tokens (#93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
           path: packages/astropress/dist
       - run: bun run --filter astropress-example-gh-pages build
       - name: Deploy preview to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -136,7 +136,12 @@ jobs:
     # audit:baseline-coverage:rust + prepush-mutation-gate-rust on
     # changed files), mirroring the TS split.
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 60m was tripping on cold runs (cargo-mutants showed as "cancelled" on
+    # ffc55e2). The step itself is `|| true` and the job is continue-on-error,
+    # so only the GH job timeout can surface as a failure here; raise it well
+    # above realistic cold-run wall-clock so refresh-only never blocks the
+    # workflow conclusion.
+    timeout-minutes: 240
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "astropress-monorepo",
       "dependencies": {
-        "@astrojs/starlight": "^0.38.4",
+        "@astrojs/starlight": "^0.39.2",
         "astro": "^6.3.3",
         "sanitize-html": "^2.17.4",
         "vitest": "^4.1.5",
@@ -13,13 +13,13 @@
       "devDependencies": {
         "@astropress-diy/astropress": "workspace:*",
         "@axe-core/playwright": "^4.11.2",
-        "@biomejs/biome": "2.4.14",
+        "@biomejs/biome": "2.4.15",
         "@playwright/test": "^1.59.1",
         "@size-limit/file": "^12.1.0",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/jsdom": "^28.0.1",
-        "@types/node": "^24.12.2",
+        "@types/node": "^25.8.0",
         "axe-core": "^4.11.3",
         "dependency-cruiser": "^17.3.10",
         "htmlparser2": "^12.0.0",
@@ -38,7 +38,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
-        "@types/node": "^24.3.0",
+        "@types/node": "^25.8.0",
         "typescript": "6.0.3",
       },
     },
@@ -46,7 +46,7 @@
       "name": "astropress-example-gh-pages",
       "dependencies": {
         "@astropress-diy/astropress": "workspace:*",
-        "astro": "6.2.2",
+        "astro": "6.3.3",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -59,11 +59,11 @@
       "name": "astropress-example-npm-consumer-smoke",
       "dependencies": {
         "@astropress-diy/astropress": "workspace:*",
-        "astro": "6.2.2",
+        "astro": "6.3.3",
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
-        "@types/node": "^24.3.0",
+        "@types/node": "^25.8.0",
         "typescript": "6.0.3",
       },
     },
@@ -82,7 +82,7 @@
         "@astrojs/check": "^0.9.8",
         "@changesets/cli": "^2.31.0",
         "@vitest/coverage-v8": "^4.1.5",
-        "astro": "^6.2.2",
+        "astro": "^6.3.3",
         "htmlparser2": "^12.0.0",
         "schema-dts": "^2.0.0",
         "typescript": "6.0.3",
@@ -103,7 +103,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
       },
       "devDependencies": {
-        "@types/node": "^24.0.0",
+        "@types/node": "^25.8.0",
         "typescript": "6.0.3",
       },
     },
@@ -118,7 +118,7 @@
         "hono": "^4.12.14",
       },
       "devDependencies": {
-        "@types/node": "^24.0.0",
+        "@types/node": "^25.8.0",
         "typescript": "6.0.3",
         "vitest": "^4.1.5",
       },
@@ -126,8 +126,8 @@
     "packages/docs": {
       "name": "astropress-docs",
       "dependencies": {
-        "@astrojs/starlight": "^0.38.3",
-        "astro": "^6.2.2",
+        "@astrojs/starlight": "^0.39.2",
+        "astro": "^6.3.3",
         "sharp": "^0.34.5",
       },
       "devDependencies": {
@@ -164,15 +164,15 @@
 
     "@astrojs/language-server": ["@astrojs/language-server@2.16.6", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.3", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.15", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug=="],
 
-    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.8.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ=="],
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q=="],
 
-    "@astrojs/mdx": ["@astrojs/mdx@5.0.3", "", { "dependencies": { "@astrojs/markdown-remark": "7.1.0", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg=="],
+    "@astrojs/mdx": ["@astrojs/mdx@5.0.6", "", { "dependencies": { "@astrojs/markdown-remark": "7.1.2", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw=="],
 
-    "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
+    "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
     "@astrojs/sitemap": ["@astrojs/sitemap@3.7.2", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA=="],
 
-    "@astrojs/starlight": ["@astrojs/starlight@0.38.4", "", { "dependencies": { "@astrojs/markdown-remark": "^7.0.0", "@astrojs/mdx": "^5.0.0", "@astrojs/sitemap": "^3.7.1", "@pagefind/default-ui": "^1.3.0", "@types/hast": "^3.0.4", "@types/js-yaml": "^4.0.9", "@types/mdast": "^4.0.4", "astro-expressive-code": "^0.41.6", "bcp-47": "^2.1.0", "hast-util-from-html": "^2.0.1", "hast-util-select": "^6.0.2", "hast-util-to-string": "^3.0.0", "hastscript": "^9.0.0", "i18next": "^23.11.5", "js-yaml": "^4.1.0", "klona": "^2.0.6", "magic-string": "^0.30.17", "mdast-util-directive": "^3.0.0", "mdast-util-to-markdown": "^2.1.0", "mdast-util-to-string": "^4.0.0", "pagefind": "^1.3.0", "rehype": "^13.0.1", "rehype-format": "^5.0.0", "remark-directive": "^3.0.0", "ultrahtml": "^1.6.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "vfile": "^6.0.2" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-TGFIr2aVC+gcZCPQzJOO4ZnA/yL3jRnsUDcKlVdEhxhxaOQnWr9lZ9MRScg9zU6uh3HVeZAmmjkLCdTlHdcaZA=="],
+    "@astrojs/starlight": ["@astrojs/starlight@0.39.2", "", { "dependencies": { "@astrojs/markdown-remark": "^7.1.1", "@astrojs/mdx": "^5.0.4", "@astrojs/sitemap": "^3.7.2", "@pagefind/default-ui": "^1.3.0", "@types/hast": "^3.0.4", "@types/js-yaml": "^4.0.9", "@types/mdast": "^4.0.4", "astro-expressive-code": "^0.42.0", "bcp-47": "^2.1.0", "hast-util-from-html": "^2.0.3", "hast-util-select": "^6.0.4", "hast-util-to-string": "^3.0.1", "hastscript": "^9.0.1", "i18next": "^26.0.7", "js-yaml": "^4.1.1", "klona": "^2.0.6", "magic-string": "^0.30.21", "mdast-util-directive": "^3.1.0", "mdast-util-to-markdown": "^2.1.2", "mdast-util-to-string": "^4.0.0", "pagefind": "^1.3.0", "rehype": "^13.0.2", "rehype-format": "^5.0.1", "remark-directive": "^4.0.0", "ultrahtml": "^1.6.0", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-vlw+bwnjtf5buCTUtLU7JfV6D3knslxqnspr6LKs6hfRuFZiyr5hT44F7GyDqR9FKANUqFxnIzWM81F1k/kOUA=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
 
@@ -254,23 +254,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -398,13 +398,13 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
-    "@expressive-code/core": ["@expressive-code/core@0.41.7", "", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-ck92uZYZ9Wba2zxkiZLsZGi9N54pMSAVdrI9uW3Oo9AtLglD5RmrdTwbYPCT2S/jC36JGB2i+pnQtBm/Ib2+dg=="],
+    "@expressive-code/core": ["@expressive-code/core@0.42.0", "", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw=="],
 
-    "@expressive-code/plugin-frames": ["@expressive-code/plugin-frames@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7" } }, "sha512-diKtxjQw/979cTglRFaMCY/sR6hWF0kSMg8jsKLXaZBSfGS0I/Hoe7Qds3vVEgeoW+GHHQzMcwvgx/MOIXhrTA=="],
+    "@expressive-code/plugin-frames": ["@expressive-code/plugin-frames@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-XtkPm+941Uta7Y+81Acv+OA/20F1NJmJhCX6UYGKpqEIGqplNh3PTOhcURp6tcruhlzJcWcvpWy6Oigz3SrjqA=="],
 
-    "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7", "shiki": "^3.2.2" } }, "sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ=="],
+    "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0", "shiki": "^4.0.2" } }, "sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g=="],
 
-    "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7" } }, "sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw=="],
+    "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ=="],
 
     "@hono/node-server": ["@hono/node-server@2.0.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-n3GfHwwCvHCkGmOwKfxUPOlbfzuO64Sbc5XC4NGPIXxkuOnJrdgExdRKmHfF924r914WRJPT397GdqLvdYTeyQ=="],
 
@@ -652,7 +652,7 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
-    "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
@@ -740,7 +740,7 @@
 
     "astro": ["astro@6.3.3", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.9.1", "@astrojs/markdown-remark": "7.1.2", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g=="],
 
-    "astro-expressive-code": ["astro-expressive-code@0.41.7", "", { "dependencies": { "rehype-expressive-code": "^0.41.7" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ=="],
+    "astro-expressive-code": ["astro-expressive-code@0.42.0", "", { "dependencies": { "rehype-expressive-code": "^0.42.0" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag=="],
 
     "astropress-docs": ["astropress-docs@workspace:packages/docs"],
 
@@ -976,7 +976,7 @@
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
-    "expressive-code": ["expressive-code@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7", "@expressive-code/plugin-frames": "^0.41.7", "@expressive-code/plugin-shiki": "^0.41.7", "@expressive-code/plugin-text-markers": "^0.41.7" } }, "sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA=="],
+    "expressive-code": ["expressive-code@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0", "@expressive-code/plugin-frames": "^0.42.0", "@expressive-code/plugin-shiki": "^0.42.0", "@expressive-code/plugin-text-markers": "^0.42.0" } }, "sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1114,7 +1114,7 @@
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
-    "i18next": ["i18next@23.16.8", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg=="],
+    "i18next": ["i18next@26.2.0", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1312,7 +1312,7 @@
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
 
-    "micromark-extension-directive": ["micromark-extension-directive@3.0.2", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA=="],
+    "micromark-extension-directive": ["micromark-extension-directive@4.0.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg=="],
 
     "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
 
@@ -1570,7 +1570,7 @@
 
     "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
 
-    "rehype-expressive-code": ["rehype-expressive-code@0.41.7", "", { "dependencies": { "expressive-code": "^0.41.7" } }, "sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ=="],
+    "rehype-expressive-code": ["rehype-expressive-code@0.42.0", "", { "dependencies": { "expressive-code": "^0.42.0" } }, "sha512-8rp/1YMEVVSYbtz+bFBx+uSx3vA4i4T8RwRm5Q/IWbucQnnQqQ0hDqtmKOr8tv+59Cik6cu5aH3WPo0I7csuTA=="],
 
     "rehype-format": ["rehype-format@5.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-format": "^1.0.0" } }, "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ=="],
 
@@ -1582,7 +1582,7 @@
 
     "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
 
-    "remark-directive": ["remark-directive@3.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-directive": "^3.0.0", "micromark-extension-directive": "^3.0.0", "unified": "^11.0.0" } }, "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A=="],
+    "remark-directive": ["remark-directive@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-directive": "^3.0.0", "micromark-extension-directive": "^4.0.0", "unified": "^11.0.0" } }, "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
@@ -1922,8 +1922,6 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@astrojs/markdown-remark/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.8.0", "", { "dependencies": { "picomatch": "^4.0.3" } }, "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w=="],
-
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1939,8 +1937,6 @@
     "@changesets/cli/package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
-
-    "@expressive-code/plugin-shiki/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "@inquirer/core/fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
@@ -1958,7 +1954,11 @@
 
     "@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
-    "@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "@types/jsdom/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "@types/sax/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -1967,8 +1967,6 @@
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "astro/@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q=="],
 
     "cross-spawn/path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -2008,6 +2006,8 @@
 
     "sanitize-html/htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
+    "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
@@ -2022,21 +2022,11 @@
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "@expressive-code/plugin-shiki/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
-
-    "@expressive-code/plugin-shiki/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
-
-    "@expressive-code/plugin-shiki/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
-
-    "@expressive-code/plugin-shiki/shiki/@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
-
-    "@expressive-code/plugin-shiki/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
-
-    "@expressive-code/plugin-shiki/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
-
     "@inquirer/core/fast-wrap-ansi/fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "astro/@astrojs/markdown-remark/@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
+    "@types/jsdom/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/sax/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "css-select/domhandler/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
@@ -2055,6 +2045,8 @@
     "sanitize-html/htmlparser2/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "sanitize-html/htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "sitemap/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -3,7 +3,7 @@
 Auto-generated from TypeScript source via the TypeScript compiler API.
 Run `bun run docs:api` to regenerate.
 
-Generated: 2026-05-10
+Generated: 2026-05-18
 
 ---
 
@@ -619,6 +619,16 @@ function listOAuthProviders(domain: IntegrationDomain): readonly OAuthProviderDe
 #### `registerOAuthProvider`
 ```ts
 function registerOAuthProvider(def: OAuthProviderDefinition): OAuthProviderDefinition
+```
+
+#### `sealOAuthCallbackTokens`
+```ts
+function sealOAuthCallbackTokens(locals: Locals | null | undefined, input: SealOAuthCallbackInput): Promise<SealOAuthCallbackResult>
+```
+
+#### `tokensToSecretFields`
+```ts
+function tokensToSecretFields(tokens: OAuthTokenSet): Record<string, string>
 ```
 
 #### `buildAuthorizeRedirect`
@@ -1592,6 +1602,9 @@ function createAstropressVitestLocalRuntimePlugins(localRuntimeModulesPath: stri
 - `interface ConnectIntegrationParams`
 - `type ConnectIntegrationResult`
 - `interface OAuthProviderDefinition`
+- `type SealOAuthCallbackErrorCode`
+- `interface SealOAuthCallbackInput`
+- `type SealOAuthCallbackResult`
 - `interface BuildAuthorizeRedirectArgs`
 - `interface BuildAuthorizeRedirectResult`
 - `interface IssuedOAuthState`

--- a/examples/admin-harness/package.json
+++ b/examples/admin-harness/package.json
@@ -13,7 +13,7 @@
 	},
 	"devDependencies": {
 		"@astrojs/check": "^0.9.8",
-		"@types/node": "^24.3.0",
+		"@types/node": "^25.8.0",
 		"typescript": "6.0.3"
 	}
 }

--- a/examples/github-pages/package.json
+++ b/examples/github-pages/package.json
@@ -13,7 +13,7 @@
 		"prepare": "bunx lefthook install"
 	},
 	"dependencies": {
-		"astro": "6.2.2",
+		"astro": "6.3.3",
 		"@astropress-diy/astropress": "workspace:*"
 	},
 	"devDependencies": {

--- a/examples/npm-consumer-smoke/package.json
+++ b/examples/npm-consumer-smoke/package.json
@@ -8,7 +8,7 @@
 		"check": "astro check"
 	},
 	"dependencies": {
-		"astro": "6.2.2",
+		"astro": "6.3.3",
 		"@astropress-diy/astropress": "workspace:*"
 	},
 	"devDependencies": {

--- a/examples/npm-consumer-smoke/package.json
+++ b/examples/npm-consumer-smoke/package.json
@@ -13,7 +13,7 @@
 	},
 	"devDependencies": {
 		"@astrojs/check": "^0.9.8",
-		"@types/node": "^24.3.0",
+		"@types/node": "^25.8.0",
 		"typescript": "6.0.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
 		"node": ">=24.8.0"
 	},
 	"dependencies": {
-		"@astrojs/starlight": "^0.38.4",
+		"@astrojs/starlight": "^0.39.2",
 		"astro": "^6.3.3",
 		"sanitize-html": "^2.17.4",
 		"vitest": "^4.1.5"

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
 		"@playwright/test": "^1.59.1",
 		"@size-limit/file": "^12.1.0",
 		"@types/jsdom": "^28.0.1",
-		"@types/node": "^24.12.2",
+		"@types/node": "^25.8.0",
 		"axe-core": "^4.11.3",
 		"dependency-cruiser": "^17.3.10",
 		"htmlparser2": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
 	},
 	"devDependencies": {
 		"@astropress-diy/astropress": "workspace:*",
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.4.15",
 		"@stryker-mutator/core": "^9.6.1",
 		"@stryker-mutator/vitest-runner": "^9.6.1",
 		"@axe-core/playwright": "^4.11.2",

--- a/packages/astropress-mcp/package.json
+++ b/packages/astropress-mcp/package.json
@@ -19,7 +19,7 @@
 		"@modelcontextprotocol/sdk": "^1.29.0"
 	},
 	"devDependencies": {
-		"@types/node": "^24.0.0",
+		"@types/node": "^25.8.0",
 		"typescript": "6.0.3"
 	},
 	"engines": {

--- a/packages/astropress-nexus/package.json
+++ b/packages/astropress-nexus/package.json
@@ -27,7 +27,7 @@
 	"devDependencies": {
 		"typescript": "6.0.3",
 		"vitest": "^4.1.5",
-		"@types/node": "^24.0.0"
+		"@types/node": "^25.8.0"
 	},
 	"engines": {
 		"node": ">=24.8.0"

--- a/packages/astropress/index.ts
+++ b/packages/astropress/index.ts
@@ -362,6 +362,15 @@ export {
 	registerOAuthProvider,
 } from "./src/integrations/oauth/registry.js";
 export type {
+	SealOAuthCallbackErrorCode,
+	SealOAuthCallbackInput,
+	SealOAuthCallbackResult,
+} from "./src/integrations/oauth/seal-callback";
+export {
+	sealOAuthCallbackTokens,
+	tokensToSecretFields,
+} from "./src/integrations/oauth/seal-callback.js";
+export type {
 	BuildAuthorizeRedirectArgs,
 	BuildAuthorizeRedirectResult,
 } from "./src/integrations/oauth/start";

--- a/packages/astropress/package.json
+++ b/packages/astropress/package.json
@@ -468,7 +468,7 @@
 		"@astrojs/check": "^0.9.8",
 		"@changesets/cli": "^2.31.0",
 		"@vitest/coverage-v8": "^4.1.5",
-		"astro": "^6.2.2",
+		"astro": "^6.3.3",
 		"htmlparser2": "^12.0.0",
 		"schema-dts": "^2.0.0",
 		"typescript": "6.0.3",

--- a/packages/astropress/pages/ap-admin/oauth/callback/[provider].ts
+++ b/packages/astropress/pages/ap-admin/oauth/callback/[provider].ts
@@ -3,6 +3,7 @@ import {
 	exchangeCodeForToken,
 	getAstropressRootSecretCandidates,
 	getOAuthProvider,
+	sealOAuthCallbackTokens,
 	verifyOAuthState,
 } from "@astropress-diy/astropress";
 import type { APIRoute } from "astro";
@@ -11,13 +12,23 @@ import type { APIRoute } from "astro";
  * OAuth authorization-code callback. The IdP redirects the operator
  * back here with `?code=…&state=…`; we verify the state under the
  * rootSecret, exchange the code for tokens against the provider's
- * `tokenUrl`, and redirect back to the original `returnTo`.
+ * `tokenUrl`, seal the tokens via the Phase 2 envelope into
+ * `integration_secrets`, then redirect back to the original
+ * `returnTo` without surfacing any token material in the URL or
+ * response body.
  *
- * Token sealing through the Phase 2 envelope is intentionally
- * deferred — the route lays down the full state-verify + token-
- * exchange path; persistence lives in a follow-up commit that wires
- * the IntegrationsRepository into the same callback context. That
- * keeps the surface area of this PR bounded.
+ * Failure modes — each maps to a fixed status + opaque body:
+ *   400 — missing query params, unrecognised state, or signature
+ *         mismatch.
+ *   404 — verified state references a provider/slug that the registry
+ *         no longer exposes.
+ *   500 — root-secret unavailable, OAuth client credentials missing,
+ *         or token sealing failed.
+ *   502 — token-endpoint exchange failed (network or HTTP error).
+ *
+ * Persistence happens inline via `sealOAuthCallbackTokens`. Sealing
+ * failures bubble up as 500 with a structured code; the route never
+ * returns success while leaving secrets unpersisted.
  */
 
 export const GET: APIRoute = async (context) => {
@@ -81,11 +92,23 @@ export const GET: APIRoute = async (context) => {
 		});
 	}
 
-	// TODO: seal `result.tokens` via Phase 2 envelope into
-	// integration_secrets. Until that lands, redirect back with a
-	// query flag so the operator sees that the OAuth round-trip
-	// completed end-to-end.
+	const sealed = await sealOAuthCallbackTokens(context.locals, {
+		domain: verified.context.domain,
+		provider: provider.id,
+		tokens: result.tokens,
+		rootSecret,
+		now: new Date().toISOString(),
+	});
+	if (!sealed.ok) {
+		// Opaque code only — never include any part of `result.tokens` in
+		// the response. The structured code is enough for the operator to
+		// surface in the admin UI; the underlying error is captured in
+		// the runtime log via the repo layer.
+		return new Response(`OAuth token persistence failed: ${sealed.code}`, {
+			status: 500,
+		});
+	}
+
 	const returnTo = verified.context.returnTo || "/ap-admin/services";
-	const sep = returnTo.includes("?") ? "&" : "?";
-	return context.redirect(`${returnTo}${sep}oauth_pending_seal=1`);
+	return context.redirect(returnTo);
 };

--- a/packages/astropress/src/integrations/oauth/seal-callback.ts
+++ b/packages/astropress/src/integrations/oauth/seal-callback.ts
@@ -1,0 +1,111 @@
+/**
+ * Persistence half of the OAuth authorization-code flow.
+ *
+ * The callback route (`pages/ap-admin/oauth/callback/[provider].ts`) owns
+ * state verification, code-for-token exchange, and the final redirect.
+ * Once the exchange returns a token set, this helper seals those tokens
+ * under the Phase 2 envelope into the `integration_secrets` table via
+ * `IntegrationsRepository.connect()`.
+ *
+ * Why a separate module:
+ *   * the seal step is the only piece of the callback that touches the
+ *     runtime store, so it benefits from being unit-testable in
+ *     isolation with an in-memory SQLite repository (no Astro request
+ *     plumbing required); and
+ *   * the route file stays a thin orchestrator, which keeps the
+ *     `audit:route-http-matrix` greps stable.
+ *
+ * Plaintext discipline:
+ *   * `tokensToSecretFields` is the *only* place that copies bytes out
+ *     of `OAuthTokenSet`; everything below this layer sees the sealed
+ *     ciphertext;
+ *   * structured error shapes never include token material — see the
+ *     tests under `tests/integrations/oauth/seal-callback.test.ts`,
+ *     which assert that no error path leaks `accessToken`,
+ *     `refreshToken`, or any provider-supplied substring.
+ */
+
+import { withLocalStoreFallback } from "../../admin-store-dispatch.js";
+import type { OAuthTokenSet } from "./token-exchange";
+
+export type SealOAuthCallbackErrorCode = "INTEGRATIONS_NOT_AVAILABLE" | "SEAL_FAILED";
+
+export type SealOAuthCallbackResult =
+	| { readonly ok: true }
+	| { readonly ok: false; readonly code: SealOAuthCallbackErrorCode };
+
+export interface SealOAuthCallbackInput {
+	readonly domain: string;
+	readonly provider: string;
+	readonly tokens: OAuthTokenSet;
+	readonly rootSecret: string;
+	readonly now: string;
+}
+
+/**
+ * Project an OAuthTokenSet into the `Record<string,string>` shape that
+ * `sealIntegrationSecret` expects. `expiresIn` (a number) is stringified;
+ * optional fields are only included when present so they don't seal as
+ * the literal string "undefined".
+ *
+ * Exported (not internal) so the security tests can pin the exact key
+ * set — any field we later widen the token set to must be threaded
+ * through here, and the tests catch silent omissions.
+ */
+export function tokensToSecretFields(tokens: OAuthTokenSet): Record<string, string> {
+	const out: Record<string, string> = {
+		accessToken: tokens.accessToken,
+		tokenType: tokens.tokenType,
+	};
+	if (tokens.refreshToken !== undefined) {
+		out.refreshToken = tokens.refreshToken;
+	}
+	if (tokens.expiresIn !== undefined) {
+		out.expiresIn = String(tokens.expiresIn);
+	}
+	if (tokens.scope !== undefined) {
+		out.scope = tokens.scope;
+	}
+	return out;
+}
+
+export async function sealOAuthCallbackTokens(
+	locals: App.Locals | null | undefined,
+	input: SealOAuthCallbackInput,
+): Promise<SealOAuthCallbackResult> {
+	const secretFields = tokensToSecretFields(input.tokens);
+	return withLocalStoreFallback<SealOAuthCallbackResult>(
+		locals,
+		// D1 path: IntegrationsRepository over D1 has not landed yet
+		// (issue #81). Mirror runtime-actions-integrations.ts: return a
+		// typed INTEGRATIONS_NOT_AVAILABLE rather than silently writing
+		// to a half-implemented store.
+		async () => ({ ok: false, code: "INTEGRATIONS_NOT_AVAILABLE" }),
+		async (store) => {
+			const repo = store.integrations;
+			if (!repo) {
+				return { ok: false, code: "INTEGRATIONS_NOT_AVAILABLE" };
+			}
+			try {
+				await repo.connect(
+					{
+						domain: input.domain,
+						provider: input.provider,
+						secretFields,
+						configJson: "{}",
+						now: input.now,
+					},
+					input.rootSecret,
+				);
+				return { ok: true };
+			} catch {
+				// Swallow the error *body* deliberately — repo.connect's
+				// failure modes (DB write error, sealIntegrationSecret
+				// envelope failure) can carry input substrings in their
+				// messages, and we never want token material on the
+				// response or in audit logs from this helper.
+				return { ok: false, code: "SEAL_FAILED" };
+			}
+		},
+	);
+}

--- a/packages/astropress/tests/integrations/oauth/seal-callback.test.ts
+++ b/packages/astropress/tests/integrations/oauth/seal-callback.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Security-critical tests for the OAuth callback persistence half.
+ *
+ * Two layers are exercised here:
+ *
+ *   1. {@link sealOAuthCallbackTokens} as a unit — driven against an
+ *      in-memory SQLite IntegrationsRepository (the same one production
+ *      uses for the local-store path). These tests prove that on the
+ *      happy path the *exact* token field set lands in
+ *      `integration_secrets` under the verified `(domain, provider)`
+ *      context, and that on every failure path no token byte escapes
+ *      the helper.
+ *
+ *   2. The Astro APIRoute `GET` at
+ *      `pages/ap-admin/oauth/callback/[provider].ts` driven through a
+ *      mocked `loadLocalAdminStore` + mocked `fetch` so we can assert
+ *      the route as a whole — including the redirect — never embeds
+ *      a token in the response.
+ *
+ * These tests are deliberately verbose: each negative path is a
+ * separate `it` block so a future regression that, say, starts echoing
+ * the structured error code with `result.tokens.accessToken`
+ * concatenated will be reported as exactly one targeted failure.
+ *
+ * Plaintext-leak invariants — repeated across every negative-path
+ * test — are the core security guarantee. The CANARY strings are
+ * wired through `OAuthTokenSet` so a single grep over the response
+ * body / redirect URL is sufficient to detect leakage of *any*
+ * token field.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` is hoisted to the top of the module, so any state it
+// captures must come from `vi.hoisted` — that runs first.
+const mockState = vi.hoisted(() => ({
+	store: { integrations: undefined } as {
+		integrations:
+			| import("../../../src/sqlite-runtime/integrations").IntegrationsRepository
+			| undefined;
+	},
+}));
+vi.mock("../../../src/local-runtime-modules", () => ({
+	loadLocalAdminStore: async () => mockState.store,
+}));
+vi.mock("../../../src/local-runtime-modules.js", () => ({
+	loadLocalAdminStore: async () => mockState.store,
+}));
+
+import { issueOAuthState } from "../../../index";
+// Imported after the mock so the route's transitive imports of
+// `local-runtime-modules` resolve to our hoisted stub.
+import { GET } from "../../../pages/ap-admin/oauth/callback/[provider].js";
+import {
+	_resetOAuthRegistryForTests,
+	type OAuthProviderDefinition,
+	registerOAuthProvider,
+} from "../../../src/integrations/oauth/registry";
+import {
+	type SealOAuthCallbackResult,
+	sealOAuthCallbackTokens,
+	tokensToSecretFields,
+} from "../../../src/integrations/oauth/seal-callback";
+import type { OAuthTokenSet } from "../../../src/integrations/oauth/token-exchange";
+import {
+	createIntegrationsRepository,
+	type IntegrationsRepository,
+} from "../../../src/sqlite-runtime/integrations";
+import { makeDb } from "../../helpers/make-db.js";
+
+// -----------------------------------------------------------------------------
+// CANARIES — every leak assertion below scans for these literals. Keep them
+// distinctive so a future grep-based regression check can find them too.
+// -----------------------------------------------------------------------------
+const CANARY_ACCESS = "CANARY-access-9f3a2d1c";
+const CANARY_REFRESH = "CANARY-refresh-7b8e4f6a";
+const CANARY_SCOPE = "CANARY-scope-read:write";
+const ROOT = "test-root-current";
+const PREV_ROOT = "test-root-previous";
+const NOW = "2026-05-18T12:00:00.000Z";
+const DOMAIN = "newsletter";
+const PROVIDER_ID = "listmonk";
+
+const TOKENS: OAuthTokenSet = {
+	accessToken: CANARY_ACCESS,
+	tokenType: "Bearer",
+	refreshToken: CANARY_REFRESH,
+	expiresIn: 3600,
+	scope: CANARY_SCOPE,
+};
+
+function assertNoTokenLeak(haystack: string): void {
+	expect(haystack).not.toContain(CANARY_ACCESS);
+	expect(haystack).not.toContain(CANARY_REFRESH);
+	expect(haystack).not.toContain(CANARY_SCOPE);
+}
+
+const REGISTERED_PROVIDER: OAuthProviderDefinition = {
+	id: PROVIDER_ID,
+	domain: DOMAIN,
+	label: "Listmonk OAuth",
+	authorizationUrl: "https://idp.example.test/authorize",
+	tokenUrl: "https://idp.example.test/token",
+	scopes: ["read:subs"],
+	clientIdEnv: "LISTMONK_OAUTH_CLIENT_ID",
+	clientSecretEnv: "LISTMONK_OAUTH_CLIENT_SECRET",
+	redirectPath: "/ap-admin/oauth/callback/listmonk",
+};
+
+let db: DatabaseSync;
+let repo: IntegrationsRepository;
+
+beforeEach(() => {
+	db = makeDb();
+	db.exec("PRAGMA foreign_keys = ON");
+	repo = createIntegrationsRepository({
+		getDb: () => db as never,
+		now: () => NOW,
+	});
+	mockState.store = { integrations: repo };
+	_resetOAuthRegistryForTests();
+	registerOAuthProvider(REGISTERED_PROVIDER);
+});
+
+afterEach(() => {
+	_resetOAuthRegistryForTests();
+	vi.unstubAllGlobals();
+});
+
+// -----------------------------------------------------------------------------
+// Layer 1: helper-level tests
+// -----------------------------------------------------------------------------
+
+describe("tokensToSecretFields", () => {
+	it("projects every OAuthTokenSet field that is present", () => {
+		expect(tokensToSecretFields(TOKENS)).toEqual({
+			accessToken: CANARY_ACCESS,
+			tokenType: "Bearer",
+			refreshToken: CANARY_REFRESH,
+			expiresIn: "3600",
+			scope: CANARY_SCOPE,
+		});
+	});
+
+	it("omits optional fields when absent (no 'undefined' literal sealed)", () => {
+		const fields = tokensToSecretFields({
+			accessToken: CANARY_ACCESS,
+			tokenType: "Bearer",
+		});
+		expect(fields).toEqual({ accessToken: CANARY_ACCESS, tokenType: "Bearer" });
+		expect("refreshToken" in fields).toBe(false);
+		expect("expiresIn" in fields).toBe(false);
+		expect("scope" in fields).toBe(false);
+	});
+
+	it("stringifies expiresIn so the secret store sees Record<string,string>", () => {
+		const fields = tokensToSecretFields({
+			accessToken: CANARY_ACCESS,
+			tokenType: "Bearer",
+			expiresIn: 0,
+		});
+		// Even the falsy 0 must be preserved as "0" — a regression that drops
+		// expiresIn when it equals zero would silently lose expiry telemetry.
+		expect(fields.expiresIn).toBe("0");
+	});
+});
+
+describe("sealOAuthCallbackTokens — helper-level success", () => {
+	it("persists a sealed row that round-trips to the exact token field set", async () => {
+		const result = await sealOAuthCallbackTokens(undefined, {
+			domain: DOMAIN,
+			provider: PROVIDER_ID,
+			tokens: TOKENS,
+			rootSecret: ROOT,
+			now: NOW,
+		});
+		expect(result).toEqual({ ok: true });
+
+		const opened = await repo.findSecret(DOMAIN, PROVIDER_ID, { current: ROOT });
+		expect(opened).toEqual({
+			accessToken: CANARY_ACCESS,
+			tokenType: "Bearer",
+			refreshToken: CANARY_REFRESH,
+			expiresIn: "3600",
+			scope: CANARY_SCOPE,
+		});
+
+		const status = repo.findStatus(DOMAIN, PROVIDER_ID);
+		expect(status).toMatchObject({
+			domain: DOMAIN,
+			provider: PROVIDER_ID,
+			status: "connected",
+			connectedAt: NOW,
+			// configJson must be the literal "{}" — the row is OAuth-managed
+			// and has no per-host provider config; a regression that wrote
+			// e.g. "" would still be valid JSON-ish but break the runtime
+			// JSON.parse path on read.
+			configJson: "{}",
+		});
+	});
+
+	it("never writes the plaintext access token into any column", async () => {
+		await sealOAuthCallbackTokens(undefined, {
+			domain: DOMAIN,
+			provider: PROVIDER_ID,
+			tokens: TOKENS,
+			rootSecret: ROOT,
+			now: NOW,
+		});
+		const allRows = [
+			...(db.prepare("SELECT * FROM connected_integrations").all() as Record<string, unknown>[]),
+			...(db.prepare("SELECT * FROM integration_secrets").all() as Record<string, unknown>[]),
+		];
+		assertNoTokenLeak(JSON.stringify(allRows));
+	});
+
+	it("rotation: a row sealed under PREV_ROOT is opened and resealed under ROOT", async () => {
+		// 1. Seal under PREV_ROOT, then flip the row's kid to mimic a
+		//    pre-rotation record — matches integrations-repository.test
+		//    rotation pattern.
+		await sealOAuthCallbackTokens(undefined, {
+			domain: DOMAIN,
+			provider: PROVIDER_ID,
+			tokens: TOKENS,
+			rootSecret: PREV_ROOT,
+			now: NOW,
+		});
+		db.prepare("UPDATE integration_secrets SET kid='previous' WHERE domain=? AND provider=?").run(
+			DOMAIN,
+			PROVIDER_ID,
+		);
+
+		// 2. findSecret with {current: ROOT, previous: PREV_ROOT}: the
+		//    "previous" candidate decrypts and reseal-on-read upgrades.
+		const opened = await repo.findSecret(DOMAIN, PROVIDER_ID, {
+			current: ROOT,
+			previous: PREV_ROOT,
+		});
+		expect(opened).toMatchObject({ accessToken: CANARY_ACCESS });
+
+		const after = db
+			.prepare("SELECT kid FROM integration_secrets WHERE domain=? AND provider=?")
+			.get(DOMAIN, PROVIDER_ID) as { kid: string };
+		expect(after.kid).toBe("current");
+	});
+});
+
+describe("sealOAuthCallbackTokens — failure paths never leak tokens", () => {
+	it("returns INTEGRATIONS_NOT_AVAILABLE when the local store has no integrations repo", async () => {
+		mockState.store = { integrations: undefined };
+		const result = await sealOAuthCallbackTokens(undefined, {
+			domain: DOMAIN,
+			provider: PROVIDER_ID,
+			tokens: TOKENS,
+			rootSecret: ROOT,
+			now: NOW,
+		});
+		expect(result).toEqual({ ok: false, code: "INTEGRATIONS_NOT_AVAILABLE" });
+		assertNoTokenLeak(JSON.stringify(result));
+	});
+
+	it("returns SEAL_FAILED when repo.connect throws, with no token bytes in the result", async () => {
+		const throwingRepo: IntegrationsRepository = {
+			...repo,
+			connect: async () => {
+				// Deliberately include the access-token canary in the
+				// thrown message — the helper must NOT surface it.
+				throw new Error(`db write failed for token=${CANARY_ACCESS}`);
+			},
+		};
+		mockState.store = { integrations: throwingRepo };
+
+		const result: SealOAuthCallbackResult = await sealOAuthCallbackTokens(undefined, {
+			domain: DOMAIN,
+			provider: PROVIDER_ID,
+			tokens: TOKENS,
+			rootSecret: ROOT,
+			now: NOW,
+		});
+		expect(result).toEqual({ ok: false, code: "SEAL_FAILED" });
+		assertNoTokenLeak(JSON.stringify(result));
+	});
+
+	it("D1 path returns INTEGRATIONS_NOT_AVAILABLE (issue #81 not yet wired)", async () => {
+		const localsWithD1 = {
+			runtime: { env: { DB: { prepare: () => ({ all: () => [] }) } } },
+		} as unknown as App.Locals;
+		const result = await sealOAuthCallbackTokens(localsWithD1, {
+			domain: DOMAIN,
+			provider: PROVIDER_ID,
+			tokens: TOKENS,
+			rootSecret: ROOT,
+			now: NOW,
+		});
+		expect(result).toEqual({ ok: false, code: "INTEGRATIONS_NOT_AVAILABLE" });
+		assertNoTokenLeak(JSON.stringify(result));
+	});
+});
+
+// -----------------------------------------------------------------------------
+// Layer 2: end-to-end through the Astro APIRoute GET handler
+// -----------------------------------------------------------------------------
+
+function makeLocals(overrides?: Partial<Record<string, string>>): App.Locals {
+	return {
+		runtime: {
+			env: {
+				ASTROPRESS_ROOT_SECRET: ROOT,
+				LISTMONK_OAUTH_CLIENT_ID: "cid-test",
+				LISTMONK_OAUTH_CLIENT_SECRET: "csec-test",
+				...overrides,
+			},
+		},
+	} as unknown as App.Locals;
+}
+
+async function buildContext(opts: {
+	stateToken?: string;
+	code?: string;
+	providerSlug?: string;
+	locals?: App.Locals;
+}) {
+	const url = new URL(
+		`https://host.example.test/ap-admin/oauth/callback/${opts.providerSlug ?? "listmonk"}?code=${
+			opts.code ?? "code-abc"
+		}&state=${opts.stateToken ?? ""}`,
+	);
+	const redirects: string[] = [];
+	const redirect = (path: string) => {
+		redirects.push(path);
+		return new Response(null, { status: 302, headers: { Location: path } });
+	};
+	const context = {
+		url,
+		params: { provider: opts.providerSlug ?? "listmonk" },
+		locals: opts.locals ?? makeLocals(),
+		redirect,
+	};
+	return { context, redirects };
+}
+
+function mockTokenExchangeFetch(tokens: OAuthTokenSet | "network-error" | { status: number }) {
+	const fetchMock = vi.fn(async () => {
+		if (tokens === "network-error") {
+			throw new Error("ECONNREFUSED");
+		}
+		if (typeof tokens === "object" && "status" in tokens) {
+			return new Response("err", { status: tokens.status });
+		}
+		const body: Record<string, unknown> = {
+			access_token: tokens.accessToken,
+			token_type: tokens.tokenType,
+		};
+		if (tokens.refreshToken) body.refresh_token = tokens.refreshToken;
+		if (tokens.expiresIn !== undefined) body.expires_in = tokens.expiresIn;
+		if (tokens.scope) body.scope = tokens.scope;
+		return new Response(JSON.stringify(body), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+async function makeValidState(overrides?: { providerId?: string; domain?: string }) {
+	const issued = await issueOAuthState({
+		context: {
+			domain: overrides?.domain ?? DOMAIN,
+			providerId: overrides?.providerId ?? PROVIDER_ID,
+			returnTo: "/ap-admin/services",
+		},
+		rootSecret: ROOT,
+		nowMs: Date.now(),
+	});
+	return issued.token;
+}
+
+describe("ap-admin/oauth/callback/[provider] GET — security regression suite", () => {
+	it("happy path: persists the sealed row and redirects to returnTo with no token in the URL", async () => {
+		mockTokenExchangeFetch(TOKENS);
+		const state = await makeValidState();
+		const { context, redirects } = await buildContext({ stateToken: state });
+
+		const response = await GET(context as never);
+		expect(response.status).toBe(302);
+		expect(redirects).toHaveLength(1);
+
+		// Redirect target must NOT contain any token field — neither
+		// as a query param nor anywhere in the URL.
+		assertNoTokenLeak(redirects[0]);
+		// The legacy `oauth_pending_seal` query flag must be gone — the
+		// issue's acceptance criterion explicitly requires it removed.
+		expect(redirects[0]).not.toContain("oauth_pending_seal");
+		expect(redirects[0]).toBe("/ap-admin/services");
+
+		// Row in DB matches the token set we mocked back from fetch.
+		const opened = await repo.findSecret(DOMAIN, PROVIDER_ID, { current: ROOT });
+		expect(opened).toMatchObject({ accessToken: CANARY_ACCESS });
+	});
+
+	it("seal failure surfaces 500 with the structured code and zero token bytes in the body", async () => {
+		mockState.store = {
+			integrations: {
+				...repo,
+				connect: async () => {
+					throw new Error(`db unavailable, token=${CANARY_ACCESS}`);
+				},
+			},
+		};
+		mockTokenExchangeFetch(TOKENS);
+		const state = await makeValidState();
+		const { context } = await buildContext({ stateToken: state });
+
+		const response = await GET(context as never);
+		expect(response.status).toBe(500);
+		const body = await response.text();
+		expect(body).toContain("SEAL_FAILED");
+		assertNoTokenLeak(body);
+	});
+
+	it("INTEGRATIONS_NOT_AVAILABLE: 500 with code, no token bytes in body, no DB write", async () => {
+		mockState.store = { integrations: undefined };
+		mockTokenExchangeFetch(TOKENS);
+		const state = await makeValidState();
+		const { context } = await buildContext({ stateToken: state });
+
+		const response = await GET(context as never);
+		expect(response.status).toBe(500);
+		const body = await response.text();
+		expect(body).toContain("INTEGRATIONS_NOT_AVAILABLE");
+		assertNoTokenLeak(body);
+		expect(repo.findStatus(DOMAIN, PROVIDER_ID)).toBeUndefined();
+	});
+
+	it("state token missing → 400, never invokes fetch", async () => {
+		const fetchMock = mockTokenExchangeFetch(TOKENS);
+		const { context } = await buildContext({ stateToken: "" });
+		const response = await GET(context as never);
+		expect(response.status).toBe(400);
+		expect(fetchMock).not.toHaveBeenCalled();
+		assertNoTokenLeak(await response.text());
+	});
+
+	it("state token forged (bad signature) → 400, never invokes fetch, never seals", async () => {
+		const fetchMock = mockTokenExchangeFetch(TOKENS);
+		const forged = Buffer.from(
+			JSON.stringify({
+				n: "abc",
+				c: { domain: DOMAIN, providerId: PROVIDER_ID, returnTo: "/x" },
+				e: Date.now() + 60_000,
+				s: "deadbeef",
+			}),
+			"utf-8",
+		).toString("hex");
+		const { context } = await buildContext({ stateToken: forged });
+		const response = await GET(context as never);
+		expect(response.status).toBe(400);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(repo.findStatus(DOMAIN, PROVIDER_ID)).toBeUndefined();
+		assertNoTokenLeak(await response.text());
+	});
+
+	it("provider slug mismatch (state says listmonk, URL says github) → 404, never seals", async () => {
+		const fetchMock = mockTokenExchangeFetch(TOKENS);
+		const state = await makeValidState();
+		const { context } = await buildContext({ stateToken: state, providerSlug: "github" });
+		const response = await GET(context as never);
+		expect(response.status).toBe(404);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(repo.findStatus(DOMAIN, PROVIDER_ID)).toBeUndefined();
+		assertNoTokenLeak(await response.text());
+	});
+
+	it("missing client credentials → 500, never invokes fetch, never seals", async () => {
+		const fetchMock = mockTokenExchangeFetch(TOKENS);
+		const state = await makeValidState();
+		const localsNoCreds = {
+			runtime: { env: { ASTROPRESS_ROOT_SECRET: ROOT } },
+		} as unknown as App.Locals;
+		const { context } = await buildContext({ stateToken: state, locals: localsNoCreds });
+		const response = await GET(context as never);
+		expect(response.status).toBe(500);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(repo.findStatus(DOMAIN, PROVIDER_ID)).toBeUndefined();
+		assertNoTokenLeak(await response.text());
+	});
+
+	it("token-exchange 5xx → 502, never seals (no partial state in DB)", async () => {
+		mockTokenExchangeFetch({ status: 502 });
+		const state = await makeValidState();
+		const { context } = await buildContext({ stateToken: state });
+		const response = await GET(context as never);
+		expect(response.status).toBe(502);
+		expect(repo.findStatus(DOMAIN, PROVIDER_ID)).toBeUndefined();
+		assertNoTokenLeak(await response.text());
+	});
+
+	it("token-exchange network error → 502, never seals", async () => {
+		mockTokenExchangeFetch("network-error");
+		const state = await makeValidState();
+		const { context } = await buildContext({ stateToken: state });
+		const response = await GET(context as never);
+		expect(response.status).toBe(502);
+		expect(repo.findStatus(DOMAIN, PROVIDER_ID)).toBeUndefined();
+		assertNoTokenLeak(await response.text());
+	});
+
+	it("after a successful seal, findSecret roundtrips the access token (no plaintext leak path)", async () => {
+		mockTokenExchangeFetch(TOKENS);
+		const state = await makeValidState();
+		const { context } = await buildContext({ stateToken: state });
+		await GET(context as never);
+
+		const opened = await repo.findSecret<Record<string, string>>(DOMAIN, PROVIDER_ID, {
+			current: ROOT,
+		});
+		expect(opened?.accessToken).toBe(CANARY_ACCESS);
+		expect(opened?.refreshToken).toBe(CANARY_REFRESH);
+
+		// Belt and braces: a raw row scan must not contain any canary
+		// even though decryption succeeded.
+		const dump = JSON.stringify(
+			db.prepare("SELECT * FROM integration_secrets").all() as Record<string, unknown>[],
+		);
+		assertNoTokenLeak(dump);
+	});
+});

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,8 +10,8 @@
 		"prepare": "bunx lefthook install"
 	},
 	"dependencies": {
-		"@astrojs/starlight": "^0.38.3",
-		"astro": "^6.2.2",
+		"@astrojs/starlight": "^0.39.2",
+		"astro": "^6.3.3",
 		"sharp": "^0.34.5"
 	},
 	"devDependencies": {

--- a/tooling/stryker/baseline-scores.json
+++ b/tooling/stryker/baseline-scores.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-16T05:27:31.031Z",
+  "updatedAt": "2026-05-18T09:50:42.188Z",
   "scores": {
     "packages/astropress/src/adapters/adapter-record-helpers.ts": {
       "score": 100,
@@ -1100,6 +1100,10 @@
     "packages/astropress/src/runtime-actions-taxonomies-helpers.ts": {
       "score": 100,
       "hash": "65de638f956f345203b2c7bf9eff018659821d02"
+    },
+    "packages/astropress/src/integrations/oauth/seal-callback.ts": {
+      "score": 100,
+      "hash": "965c909757914522a603aa5c2023fe261493690c"
     }
   }
 }

--- a/tooling/stryker/stryker.config.mjs
+++ b/tooling/stryker/stryker.config.mjs
@@ -81,6 +81,12 @@ export default {
 		? `../../.stryker-incremental-${SHARD}.json`
 		: "../../.stryker-incremental.json",
 	timeoutMS: 120000,
+	// Cold CI shards have no `.stryker-incremental-<shard>.json` to start from,
+	// so the initial vitest dry-run executes the full suite with perTest
+	// coverage instrumentation. That exceeds Stryker's 5-minute default and
+	// killed both shards on ffc55e2 ("Initial test run timed out!"). Mirror the
+	// 15-minute ceiling already used in stryker-sync.config.mjs.
+	dryRunTimeoutMinutes: 15,
 	ignoreStatic: false,
 	thresholds: { high: 95, low: 95, break: 95 },
 };


### PR DESCRIPTION
## Summary
Single bundled PR (per repo policy) covering:

* **CI** — Stryker shards on `main` were dying at the 5-minute dry-run timeout (cold CI shards have no incremental cache to start from). Bumps `dryRunTimeoutMinutes` to 15 in `tooling/stryker/stryker.config.mjs` (mirrors `stryker-sync.config.mjs`), and lifts the `cargo-mutants` job ceiling 60 → 240 minutes so the refresh-only step stops surfacing as "cancelled".
* **Deps** — folds in dependabot #95 (`cloudflare/wrangler-action` 3→4), #94 (`@types/node` 24.12.4 → 25.8.0), #91 (`@biomejs/biome` 2.4.14 → 2.4.15), #90 (`@astrojs/starlight` 0.38.4 → 0.39.2, `astro` 6.2.2 → 6.3.3) with a refreshed `bun.lock`.
* **Issue #93** — OAuth callback now seals exchanged tokens via the Phase 2 envelope into `integration_secrets` under the verified `(domain, provider)` context. Removes the `?oauth_pending_seal=1` flag and the TODO marker.

## Security focus — verbose OAuth-seal regression suite
`packages/astropress/tests/integrations/oauth/seal-callback.test.ts` — 19 tests, **100% mutation score** on the new helper. Every negative path asserts the response body contains zero token-canary bytes and the DB has no partial state:

* helper layer: success persists exact field set; rotation upgrade `previous → current`; full column scan asserts no canary leaked into any plaintext column;
* failure paths: `INTEGRATIONS_NOT_AVAILABLE`, `SEAL_FAILED` (with a deliberately leaky thrown-error message including a canary), D1-not-wired path;
* route layer: state-missing → 400, forged-state → 400, slug mismatch → 404, missing creds → 500, token-exchange 5xx + network error → 502, seal failure → 500.

## Test plan
- [x] Local: `bun run vitest run tests/integrations/oauth/seal-callback.test.ts` — 19/19 pass.
- [x] Local mutation: `bun run raise:fast packages/astropress/src/integrations/oauth/seal-callback.ts` — 100.00%.
- [x] Pre-push gates passed (13m): unit + coverage + audits + mutation.
- [ ] PR-side CodeQL: confirm `check:pr-ghas` exits 0 on the PR merge ref once the scan post-dates the fix commit.
- [ ] Required PR checks green.

Closes #93. Supersedes #95, #94, #91, #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)