### PR TITLE
fix(ci)+feat(i18n): platform-smoke windows flake + admin/public RTL polish (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,13 @@ jobs:
   platform-smoke:
     needs: [lint, lint-rust, build]
     strategy:
+      # Without fail-fast: false, a single Windows runner flake
+      # (oven-sh/setup-bun@v2 has periodic cache-hit failures on
+      # Windows — see ffc55e2 / a0f56b9 main CI runs) cascades into
+      # cancellation of the ubuntu + macos jobs and reports the
+      # whole platform-smoke check as red on main even though the
+      # other two OSes haven't actually failed.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -228,6 +235,12 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.10"
+          # Windows runners periodically fail with a cache-hit-then-die
+          # on setup-bun (a0f56b9 main CI); disabling the per-runner
+          # bun binary cache on Windows trades ~5s of download time for
+          # a green job. The action's tarball-extract step is the
+          # flaky one.
+          no-cache: ${{ matrix.os == 'windows-latest' }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -226,6 +226,16 @@ function buildAstropressAdminDocumentTitle(title: string): string
 function buildAdminDashboardModel(locals: Locals, user: AuthUser | null | undefined, translationStatus: TranslationEntry[], deps: DashboardDeps): Promise<AdminDashboardModel>
 ```
 
+#### `isRtlLocale`
+```ts
+function isRtlLocale(locale: AdminLocale): boolean
+```
+
+#### `localeDirection`
+```ts
+function localeDirection(locale: AdminLocale): "ltr" | "rtl"
+```
+
 #### `pickAdminLocaleFromAcceptLanguage`
 ```ts
 function pickAdminLocaleFromAcceptLanguage(header: string | null | undefined): AdminLocale | null

--- a/examples/github-pages/src/components/SiteLayout.astro
+++ b/examples/github-pages/src/components/SiteLayout.astro
@@ -10,9 +10,23 @@ interface Props {
 	heading: string;
 	eyebrow?: string;
 	currentPath: string;
+	/** BCP-47 content locale; controls the rendered <html lang> + dir. */
+	lang?: string;
 }
 
-const { title, description, heading, eyebrow = "Astropress", currentPath } = Astro.props;
+const RTL_LOCALES = new Set(["ar", "he", "fa", "ur"]);
+
+const {
+	title,
+	description,
+	heading,
+	eyebrow = "Astropress",
+	currentPath,
+	lang = "en",
+} = Astro.props;
+
+const primaryLang = lang.split("-")[0].toLowerCase();
+const dir: "ltr" | "rtl" = RTL_LOCALES.has(primaryLang) ? "rtl" : "ltr";
 
 const navLinks: NavLink[] = [
 	{ href: "/", label: "Overview" },
@@ -25,7 +39,7 @@ const navLinks: NavLink[] = [
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={lang} dir={dir}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/astropress/index.ts
+++ b/packages/astropress/index.ts
@@ -143,6 +143,8 @@ export { buildAdminDashboardModel } from "./src/admin-dashboard";
 export type { AdminLocale } from "./src/admin-labels";
 export {
 	ADMIN_LOCALE_COOKIE,
+	isRtlLocale,
+	localeDirection,
 	pickAdminLocaleFromAcceptLanguage,
 	resolveAdminLocale,
 } from "./src/admin-locale.js";

--- a/packages/astropress/pages/ap-admin/accept-invite.astro
+++ b/packages/astropress/pages/ap-admin/accept-invite.astro
@@ -2,6 +2,7 @@
 import {
 	buildAcceptInvitePageModel,
 	buildAstropressAdminDocumentTitle,
+	localeDirection,
 	resolveAdminLocale,
 	resolveAstropressAdminUiConfig,
 } from "astropress";
@@ -13,11 +14,12 @@ const errorMessage =
 const model = await buildAcceptInvitePageModel(Astro.locals, token);
 const { inviteRequest } = model.data;
 const adminLocale = resolveAdminLocale(Astro);
+const adminDir = localeDirection(adminLocale);
 const adminUi = resolveAstropressAdminUiConfig(adminLocale);
 ---
 
 <!doctype html>
-<html lang={adminLocale}>
+<html lang={adminLocale} dir={adminDir}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/astropress/pages/ap-admin/login.astro
+++ b/packages/astropress/pages/ap-admin/login.astro
@@ -2,6 +2,7 @@
 import TurnstileField from "@astropress-diy/astropress/components/TurnstileField.astro";
 import {
 	buildAstropressAdminDocumentTitle,
+	localeDirection,
 	resolveAdminLocale,
 	resolveAstropressAdminUiConfig,
 } from "astropress";
@@ -12,11 +13,12 @@ const requiresChallenge = Astro.url.searchParams.get("challenge") === "1";
 const wasReset = Astro.url.searchParams.get("reset") === "1";
 const invitationAccepted = Astro.url.searchParams.get("invited") === "1";
 const adminLocale = resolveAdminLocale(Astro);
+const adminDir = localeDirection(adminLocale);
 const adminUi = resolveAstropressAdminUiConfig(adminLocale);
 ---
 
 <!doctype html>
-<html lang={adminLocale}>
+<html lang={adminLocale} dir={adminDir}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/astropress/pages/ap-admin/reset-password.astro
+++ b/packages/astropress/pages/ap-admin/reset-password.astro
@@ -2,6 +2,7 @@
 import {
 	buildAstropressAdminDocumentTitle,
 	buildResetPasswordPageModel,
+	localeDirection,
 	resolveAdminLocale,
 	resolveAstropressAdminUiConfig,
 } from "astropress";
@@ -19,11 +20,12 @@ const model = await buildResetPasswordPageModel(Astro.locals, token);
 const { request } = model.data;
 const isTokenFlow = token.length > 0;
 const adminLocale = resolveAdminLocale(Astro);
+const adminDir = localeDirection(adminLocale);
 const adminUi = resolveAstropressAdminUiConfig(adminLocale);
 ---
 
 <!doctype html>
-<html lang={adminLocale}>
+<html lang={adminLocale} dir={adminDir}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/astropress/tests/admin-rtl.test.ts
+++ b/packages/astropress/tests/admin-rtl.test.ts
@@ -40,6 +40,21 @@ describe("admin RTL plumbing", () => {
 		expect(src).toMatch(/<html\s+lang=\{adminLocale\}\s+dir=\{adminDir\}/);
 	});
 
+	it.each([
+		"pages/ap-admin/login.astro",
+		"pages/ap-admin/accept-invite.astro",
+		"pages/ap-admin/reset-password.astro",
+	])("%s emits dir={adminDir} on the html element", (relPath) => {
+		// Public admin entry pages don't use AdminLayout (they're pre-auth
+		// shells), so they must thread `dir` themselves. The previous
+		// regression — `<html lang={adminLocale}>` without `dir` — left
+		// /ap-admin/login rendered LTR even after the operator picked
+		// AR via the language selector.
+		const src = readFileSync(join(REPO_ROOT, relPath), "utf8");
+		expect(src).toMatch(/<html\s+lang=\{adminLocale\}\s+dir=\{adminDir\}/);
+		expect(src).toContain("localeDirection");
+	});
+
 	it("admin.css uses logical properties for inline-axis spacing", () => {
 		const src = readFileSync(join(REPO_ROOT, "public", "admin.css"), "utf8");
 		expect(src).toContain("inset-inline-start:");

--- a/packages/astropress/tests/public-site-integration-rtl.test.ts
+++ b/packages/astropress/tests/public-site-integration-rtl.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Smoke test for the public-site layout's RTL plumbing. We assert
+ * against `SiteLayout.astro`'s template directly (string-level grep on
+ * source) rather than booting Astro — the goal is to catch a future
+ * edit that drops the `dir` attribute or hardcodes `lang="en"`,
+ * regressing the acceptance criterion from issue #72.
+ *
+ * Why a source-text test, not a rendered-output test: the public-site
+ * layout in this repo lives under `examples/github-pages/` and is
+ * built by `astro build` only when the example site is exercised.
+ * That path runs in the `test-build-content` CI job, not the unit
+ * test suite. Pinning the template's source attributes here is the
+ * lightweight unit-side complement.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const LAYOUT_PATH = join(
+	__dirname,
+	"..",
+	"..",
+	"..",
+	"examples",
+	"github-pages",
+	"src",
+	"components",
+	"SiteLayout.astro",
+);
+
+describe("public-site SiteLayout RTL plumbing (issue #72)", () => {
+	const src = readFileSync(LAYOUT_PATH, "utf8");
+
+	it("accepts a `lang` prop (BCP-47) — defaulting to 'en'", () => {
+		expect(src).toMatch(/lang\?:\s*string/);
+		expect(src).toMatch(/lang\s*=\s*"en"/);
+	});
+
+	it("renders <html lang={lang} dir={dir}>", () => {
+		expect(src).toMatch(/<html\s+lang=\{lang\}\s+dir=\{dir\}>/);
+	});
+
+	it("classifies ar, he, fa, ur as RTL", () => {
+		// Regex on the literal set is fine for a single-source pin —
+		// the audit catches drift if the set is reordered or extended.
+		expect(src).toMatch(/RTL_LOCALES[\s\S]*"ar"[\s\S]*"he"[\s\S]*"fa"[\s\S]*"ur"/);
+	});
+
+	it("normalises a regional tag down to its primary subtag", () => {
+		// Without this, `lang="ar-EG"` would skip the RTL_LOCALES match.
+		expect(src).toMatch(/lang\.split\("-"\)\[0\]/);
+		expect(src).toMatch(/\.toLowerCase\(\)/);
+	});
+
+	it("defaults the rendered direction to ltr for unknown locales", () => {
+		// The default is implicit (the union `"ltr" | "rtl"`) but the
+		// fallback branch must be `"ltr"` so a misconfigured locale
+		// renders left-to-right rather than throwing.
+		expect(src).toMatch(/RTL_LOCALES\.has\(primaryLang\)\s*\?\s*"rtl"\s*:\s*"ltr"/);
+	});
+});


### PR DESCRIPTION
## Summary
Follow-up to PR #97. Main CI on a0f56b9 went red because the Windows runner in the `platform-smoke` matrix hit a `setup-bun@v2` cache-hit-then-die, which (with `fail-fast` defaulted to true) cancelled ubuntu + macos and painted the whole check red even though no actual test ran.

## CI fix
* `platform-smoke` matrix now has `fail-fast: false` so a single Windows flake doesn't cascade.
* `oven-sh/setup-bun@v2` uses `no-cache: true` on the Windows matrix slot (trades ~5s download for a green job).

## Issue #72 (structural RTL pieces)
Most of the RTL plumbing was already in place — `AdminLocale` union includes `ar`, `isRtlLocale` / `localeDirection` already exist, `admin-labels.ts` has full Arabic translations, `AdminLayout.astro` emits `dir={adminDir}`, and admin CSS uses logical properties. The pieces that were missing:

* Three admin entry pages bypass `AdminLayout` (login/accept-invite/reset-password) and were rendering `<html lang={adminLocale}>` without `dir`. Now thread `dir={adminDir}`.
* Public-site `SiteLayout.astro` was hardcoded `<html lang="en">`. Now accepts a `lang` prop and renders `<html lang={lang} dir={dir}>`; primary subtag normalised so `ar-EG` etc. still resolve RTL.
* `localeDirection` + `isRtlLocale` re-exported from the package root.

Tests:
* `admin-rtl.test.ts` extended to cover the three admin entry pages.
* New `public-site-integration-rtl.test.ts` pins the SiteLayout RTL plumbing (prop, attribute, RTL set, regional-tag normalisation, ltr fallback).

### Explicitly NOT in this PR — gated on issue #76
Adding `ar` to `tooling/e2e/admin-i18n-no-english-leak.spec.ts`. 835 entries in `admin-page-labels.ts` are still English placeholders carrying `TODO(i18n-ar)` markers awaiting native-speaker review (#76 tracks that work). A chrome-snapshot comparison under AR would fail on every `<h1>` / `<title>` / `<h2>` until those translations land. The spec's existing inline comment captures the dependency.

## Test plan
- [x] `bun run vitest run tests/admin-rtl.test.ts tests/public-site-integration-rtl.test.ts` — 16/16 pass
- [x] Pre-push gates: ~11 min, all green
- [x] `audit-source-test-pairing` at ceiling (35 orphan tests, unchanged)
- [ ] PR checks
- [ ] Main CI on merge

Partial close of #72. Full close gated on #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)