### PR TITLE
feat(i18n)+docs: close #72 (Arabic translation pass + AR e2e) and #28 (issue templates + intake docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Question or discussion"
+    url: https://github.com/Astropress/astropress/discussions
+    about: "For open-ended questions, design proposals, or community discussion."

--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -1,0 +1,47 @@
+---
+name: Integration request (external tool)
+about: Request a new external integration — analytics, email, A/B testing, donations, webhooks
+title: "[Integration] "
+labels: integration, enhancement
+assignees: ""
+---
+
+> **Not an integration?** For new *hosting providers or data services* (Cloudflare, Turso, Neon, Vercel, etc.) use the [adapter request template](?template=adapter_support.md). For brand-new framework capabilities use the [feature request template](?template=feature_request.md).
+
+## Tool details
+
+| Field | Value |
+|-------|-------|
+| Integration name | <!-- e.g. Plausible Analytics, Resend, GrowthBook --> |
+| Integration domain | <!-- analytics / newsletter / ab-testing / monitoring / forms / cdn-purge / search / deploy-hooks --> |
+| Official Node/Edge SDK | <!-- link to npm package or REST API docs --> |
+| Auth model | <!-- API key / OAuth 2.0 authorization-code / OAuth 2.0 client-credentials / signed webhook --> |
+
+## What does this integration let an operator do?
+
+One paragraph: what action does an admin perform through this integration that they cannot do without it?
+
+## Integration surface
+
+Tick all that apply:
+
+- [ ] **Connect**: admin enters credentials (or completes OAuth) and the integration's verify() call confirms the credentials work.
+- [ ] **Display**: integration provides data that the admin UI surfaces (stats, dashboards, logs).
+- [ ] **Trigger**: framework calls the integration on a CMS event (deploy hook, content publish, comment moderation).
+- [ ] **Receive webhook**: integration calls into Astropress at `/api/webhooks/<provider>`.
+
+## Why this provider (not a competitor)?
+
+Astropress's per-domain integration registry intentionally limits how many providers we ship per domain (see rubric 56, "no speculative features"). If two analytics providers already exist, what does this one offer that they don't?
+
+## Can you help implement it?
+
+- [ ] I can submit a draft `registerXxx()` call with a `verify()` helper.
+- [ ] I can submit tests against the provider's documented error shapes.
+- [ ] I am requesting only — please prioritise alongside other community requests.
+
+## Pointers
+
+- `packages/astropress/src/integrations/registry.ts` — registry shape
+- `packages/astropress/src/integrations/providers/` — provider implementations
+- `docs/reference/integrations.md` — public-facing reference

--- a/.github/ISSUE_TEMPLATE/language_request.md
+++ b/.github/ISSUE_TEMPLATE/language_request.md
@@ -1,0 +1,36 @@
+---
+name: Language / locale request
+about: Request a new admin or public-site language (locale)
+title: "[Locale] "
+labels: i18n, enhancement
+assignees: ""
+---
+
+## Locale details
+
+| Field | Value |
+|-------|-------|
+| Language name (English) | <!-- e.g. Portuguese, Arabic, Tagalog --> |
+| Language name (native) | <!-- e.g. Português, العربية, Tagalog --> |
+| BCP-47 code | <!-- e.g. pt, ar, tl --> |
+| Script direction | <!-- ltr / rtl --> |
+
+## What needs the locale
+
+Tick the surfaces this request covers:
+
+- [ ] Admin shell (`AdminLocale`) — sidebar, login, dashboards, content editors
+- [ ] Public-site templates — site-layout `lang`/`dir`, public-facing CMS-rendered content
+- [ ] Public-site CMS content — actual translated articles authored by operators (this is a *content* concern, not a framework concern; framework only needs to recognise the locale)
+
+## Native-speaker review
+
+The admin label catalog is large (1000+ entries split across `admin-labels.ts` and `admin-page-labels.ts`). Initial seed translations land with a `TODO(i18n-<code>): native-speaker review (issue #N)` marker. Indicate who will review:
+
+- [ ] I am a native or fluent speaker and will review the seed translations.
+- [ ] I will help recruit a reviewer.
+- [ ] I am only requesting — someone else will review.
+
+## Anything else
+
+RTL languages (Arabic, Hebrew, Persian, Urdu) need additional plumbing: the `dir="rtl"` attribute on `<html>`, mirrored iconography, and CSS logical properties throughout the admin and public site. Issue #72 tracked the Arabic pass — file a sibling issue for any new RTL language and reference it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,43 @@ Run `bun run bdd:lint` to validate feature file syntax.
 - Present-tense imperative subject line (`add focus trap to confirm dialog`)
 - Reference the feature file or test if the change is behaviour-driven
 
+## Requesting and contributing providers
+
+Astropress supports three kinds of plug-in points, each with a different intake template and a different audit gate.
+
+### Hosting providers and data services (adapters)
+
+These plug in via `AstropressPlatformAdapter` and the `verified-providers.json` registry (`packages/astropress/src/verified-providers.json`). The `audit:providers` CI check enforces that every adapter is registered with a status, contact, and supported-feature list — speculative or half-finished adapters can't land.
+
+Workflow:
+1. File an [Adapter request](.github/ISSUE_TEMPLATE/adapter_support.md) issue. Maintainers triage and tag with a provider category.
+2. Implement the adapter in `packages/astropress/src/adapters/` against the existing interface (see `docs/reference/ARCHITECTURE.md` for the contract).
+3. Add an entry to `verified-providers.json` with `status: "beta"` for the first release and the supported-feature flags filled in honestly.
+4. Run `bun run audit:providers` locally; it should pass with the new entry.
+5. Open a PR that bundles the adapter, the registry entry, and at least one integration test against a sqlite-backed fixture or a recording fixture.
+
+### External integrations (analytics, email, A/B testing, donations, webhooks…)
+
+These plug in via the per-domain integration registry (`packages/astropress/src/integrations/`). The `audit:integration-secrets` and `audit:integration-honesty` checks enforce that every provider has a Zod-validated field schema, a `verify()` helper, and no plaintext-secret leak surfaces.
+
+Workflow:
+1. File an [Integration request](.github/ISSUE_TEMPLATE/integration_request.md) issue. Pick a domain: analytics, newsletter, ab-testing, monitoring, forms, cdn-purge, search, deploy-hooks.
+2. Add a `registerXxx()` call under `packages/astropress/src/integrations/providers/`. Implement `verify()` to exercise the provider's documented error shapes.
+3. If the provider uses OAuth 2.0 authorization-code, also wire it through `pages/ap-admin/oauth/callback/[provider].ts`; tokens must seal into `integration_secrets` via the existing helper.
+4. Update `docs/reference/integrations.md` with a one-paragraph entry and a link to the provider's docs.
+5. Open a PR; CI exercises the registry + secret-store gates automatically.
+
+### New admin or content languages (locales)
+
+These plug in via the `AdminLocale` union and the `pageLabels` / `adminLabels` tables.
+
+Workflow:
+1. File a [Language request](.github/ISSUE_TEMPLATE/language_request.md) issue with a BCP-47 code and script direction.
+2. Add the code to the `AdminLocale` union in `packages/astropress/src/admin-labels.ts` and the `isAdminLocale` switch in `admin-locale.ts`.
+3. Add full translations in `admin-labels.ts` (~100 strings) and `admin-page-labels.ts` (~800 strings). Seed translations may carry a `TODO(i18n-<code>): native-speaker review (issue #N)` marker; track the review under a sibling issue.
+4. RTL languages also need `isRtlLocale` updated, and the admin/public CSS sweep must use logical properties (`margin-inline-start` etc.) — see #72 for the Arabic precedent.
+5. Run `bun run tooling/scripts/audit-admin-i18n-leaks.ts` and `bun run vitest run tests/admin-rtl.test.ts` before opening the PR.
+
 ## Opening a pull request
 
 1. `bun run test` — all tests pass

--- a/README.md
+++ b/README.md
@@ -28,7 +28,23 @@ Own your content. Choose where it lives. Export at any time. Launch your initiat
 
 It supports both **static sites** (with free hosting on, e.g, GitHub Pages or Netlify) and **dynamic sites** (on Cloudflare, Render, or your own server). Moving between them is designed to avoid rewriting your content model or admin workflows.
 
-Importing content from Wordpress or Wix, or even subscription lists from Mailchimp is easy. Add an issue if there are other platforms you want to escape the orbit of or hosting providers that can support ordinary people who just want to get to work on their dreams without becoming full-stack web developers.
+Importing content from Wordpress or Wix, or even subscription lists from Mailchimp is easy.
+
+### Requesting new platforms, integrations, or languages
+
+Five places to open an issue, picked by what you need:
+
+| You want… | Open this template |
+|-----------|--------------------|
+| A **new hosting provider** or **data service** (Cloudflare, Turso, Neon, Vercel, S3-compatible storage…) | [Adapter request](../../issues/new?template=adapter_support.md) |
+| A **new external tool** (analytics, email, A/B testing, donations, webhooks…) | [Integration request](../../issues/new?template=integration_request.md) |
+| A **new admin or content language** (locale) | [Language request](../../issues/new?template=language_request.md) |
+| A **new framework capability** (not tied to a specific provider) | [Feature request](../../issues/new?template=feature_request.md) |
+| Something is **broken** | [Bug report](../../issues/new?template=bug_report.md) |
+
+The full chooser is at [github.com/Astropress/astropress/issues/new/choose](../../issues/new/choose). For open-ended discussion (design proposals, architecture questions, "is anyone else thinking about X?") use [GitHub Discussions](https://github.com/Astropress/astropress/discussions).
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md#requesting-and-contributing-providers) for the workflow from "I filed an adapter/integration issue" to "it ships in the codebase".
 
 **Designed to work with AI.** Ask Claude, Codex, Cursor, or any AI coding assistant to scaffold your site, add features, or customise the design. Astropress ships an [MCP server](./packages/astropress-mcp/) and a machine-readable [`llms.txt`](./llms.txt) so AI tools understand the codebase out of the box.
 

--- a/packages/astropress/src/admin-page-labels.ts
+++ b/packages/astropress/src/admin-page-labels.ts
@@ -21,7 +21,7 @@ export const pageLabels = {
 	// ── Shared cross-page strings ────────────────────────────────────────────
 	"common.search": {
 		en: "Search",
-		ar: "Search", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بحث",
 		es: "Buscar",
 		fr: "Rechercher",
 		de: "Suchen",
@@ -33,7 +33,7 @@ export const pageLabels = {
 	},
 	"common.title": {
 		en: "Title",
-		ar: "Title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العنوان",
 		es: "Título",
 		fr: "Titre",
 		de: "Titel",
@@ -45,7 +45,7 @@ export const pageLabels = {
 	},
 	"common.status": {
 		en: "Status",
-		ar: "Status", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الحالة",
 		es: "Estado",
 		fr: "Statut",
 		de: "Status",
@@ -57,7 +57,7 @@ export const pageLabels = {
 	},
 	"common.actions": {
 		en: "Actions",
-		ar: "Actions", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإجراءات",
 		es: "Acciones",
 		fr: "Actions",
 		de: "Aktionen",
@@ -69,7 +69,7 @@ export const pageLabels = {
 	},
 	"common.updated": {
 		en: "Updated",
-		ar: "Updated", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حُدِّث",
 		es: "Actualizado",
 		fr: "Mis à jour",
 		de: "Aktualisiert",
@@ -81,7 +81,7 @@ export const pageLabels = {
 	},
 	"common.path": {
 		en: "Path",
-		ar: "Path", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسار",
 		es: "Ruta",
 		fr: "Chemin",
 		de: "Pfad",
@@ -93,7 +93,7 @@ export const pageLabels = {
 	},
 	"common.author": {
 		en: "Author",
-		ar: "Author", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المؤلف",
 		es: "Autor",
 		fr: "Auteur",
 		de: "Autor",
@@ -105,7 +105,7 @@ export const pageLabels = {
 	},
 	"common.category": {
 		en: "Category",
-		ar: "Category", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التصنيف",
 		es: "Categoría",
 		fr: "Catégorie",
 		de: "Kategorie",
@@ -117,7 +117,7 @@ export const pageLabels = {
 	},
 	"common.allStatuses": {
 		en: "All statuses",
-		ar: "All statuses", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل الحالات",
 		es: "Todos los estados",
 		fr: "Tous les statuts",
 		de: "Alle Status",
@@ -129,7 +129,7 @@ export const pageLabels = {
 	},
 	"common.allAuthors": {
 		en: "All authors",
-		ar: "All authors", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل المؤلفين",
 		es: "Todos los autores",
 		fr: "Tous les auteurs",
 		de: "Alle Autoren",
@@ -141,7 +141,7 @@ export const pageLabels = {
 	},
 	"common.allCategories": {
 		en: "All categories",
-		ar: "All categories", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل التصنيفات",
 		es: "Todas las categorías",
 		fr: "Toutes les catégories",
 		de: "Alle Kategorien",
@@ -153,7 +153,7 @@ export const pageLabels = {
 	},
 	"common.allTags": {
 		en: "All tags",
-		ar: "All tags", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل الوسوم",
 		es: "Todas las etiquetas",
 		fr: "Toutes les étiquettes",
 		de: "Alle Tags",
@@ -165,7 +165,7 @@ export const pageLabels = {
 	},
 	"common.clearFilters": {
 		en: "Clear filters",
-		ar: "Clear filters", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسح المرشّحات",
 		es: "Limpiar filtros",
 		fr: "Effacer les filtres",
 		de: "Filter zurücksetzen",
@@ -177,7 +177,7 @@ export const pageLabels = {
 	},
 	"common.applyFilters": {
 		en: "Apply filters",
-		ar: "Apply filters", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تطبيق المرشّحات",
 		es: "Aplicar filtros",
 		fr: "Appliquer les filtres",
 		de: "Filter anwenden",
@@ -189,7 +189,7 @@ export const pageLabels = {
 	},
 	"common.draft": {
 		en: "Draft",
-		ar: "Draft", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسودة",
 		es: "Borrador",
 		fr: "Brouillon",
 		de: "Entwurf",
@@ -201,7 +201,7 @@ export const pageLabels = {
 	},
 	"common.published": {
 		en: "Published",
-		ar: "Published", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منشور",
 		es: "Publicado",
 		fr: "Publié",
 		de: "Veröffentlicht",
@@ -213,7 +213,7 @@ export const pageLabels = {
 	},
 	"common.archived": {
 		en: "Archived",
-		ar: "Archived", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مؤرشَف",
 		es: "Archivado",
 		fr: "Archivé",
 		de: "Archiviert",
@@ -225,7 +225,7 @@ export const pageLabels = {
 	},
 	"common.scheduled": {
 		en: "Scheduled",
-		ar: "Scheduled", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مجدوَل",
 		es: "Programado",
 		fr: "Planifié",
 		de: "Geplant",
@@ -237,7 +237,7 @@ export const pageLabels = {
 	},
 	"common.inReview": {
 		en: "In Review",
-		ar: "In Review", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قيد المراجعة",
 		es: "En revisión",
 		fr: "En révision",
 		de: "In Prüfung",
@@ -249,7 +249,7 @@ export const pageLabels = {
 	},
 	"common.unscheduled": {
 		en: "Unscheduled",
-		ar: "Unscheduled", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "غير مجدوَل",
 		es: "Sin programar",
 		fr: "Non planifié",
 		de: "Ungeplant",
@@ -261,7 +261,7 @@ export const pageLabels = {
 	},
 	"common.kindPost": {
 		en: "post",
-		ar: "post", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منشور",
 		es: "publicación",
 		fr: "article",
 		de: "Beitrag",
@@ -273,7 +273,7 @@ export const pageLabels = {
 	},
 	"common.kindPage": {
 		en: "page",
-		ar: "page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحة",
 		es: "página",
 		fr: "page",
 		de: "Seite",
@@ -285,7 +285,7 @@ export const pageLabels = {
 	},
 	"common.kindRoutePage": {
 		en: "route page",
-		ar: "route page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحة المسار",
 		es: "página de ruta",
 		fr: "page de route",
 		de: "Routenseite",
@@ -297,7 +297,7 @@ export const pageLabels = {
 	},
 	"common.statusReview": {
 		en: "review",
-		ar: "review", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مراجعة",
 		es: "revisión",
 		fr: "révision",
 		de: "Prüfung",
@@ -309,7 +309,7 @@ export const pageLabels = {
 	},
 	"common.statusPending": {
 		en: "pending",
-		ar: "pending", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "معلَّق",
 		es: "pendiente",
 		fr: "en attente",
 		de: "ausstehend",
@@ -321,7 +321,7 @@ export const pageLabels = {
 	},
 	"common.needsReview": {
 		en: "Needs review",
-		ar: "Needs review", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بحاجة إلى مراجعة",
 		es: "Requiere revisión",
 		fr: "À réviser",
 		de: "Prüfung nötig",
@@ -333,7 +333,7 @@ export const pageLabels = {
 	},
 	"common.viewAll": {
 		en: "View all",
-		ar: "View all", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عرض الكل",
 		es: "Ver todo",
 		fr: "Tout afficher",
 		de: "Alle anzeigen",
@@ -345,7 +345,7 @@ export const pageLabels = {
 	},
 	"common.openQueue": {
 		en: "Open queue",
-		ar: "Open queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح قائمة الانتظار",
 		es: "Abrir cola",
 		fr: "Ouvrir la file",
 		de: "Warteschlange öffnen",
@@ -357,7 +357,7 @@ export const pageLabels = {
 	},
 	"common.openEditor": {
 		en: "Open editor",
-		ar: "Open editor", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح المحرّر",
 		es: "Abrir editor",
 		fr: "Ouvrir l'éditeur",
 		de: "Editor öffnen",
@@ -371,7 +371,7 @@ export const pageLabels = {
 	// ── Bootstrap-credentials banner (shown on every page) ───────────────────
 	"banner.bootstrap.before": {
 		en: "You're using default bootstrap credentials —",
-		ar: "You're using default bootstrap credentials —", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تستخدم بيانات اعتماد التشغيل الافتراضية —",
 		es: "Estás usando credenciales de arranque predeterminadas —",
 		fr: "Vous utilisez les identifiants par défaut —",
 		de: "Sie verwenden Standard-Bootstrap-Anmeldedaten —",
@@ -383,7 +383,7 @@ export const pageLabels = {
 	},
 	"banner.bootstrap.link": {
 		en: "change your password",
-		ar: "change your password", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "غيِّر كلمة المرور",
 		es: "cambia tu contraseña",
 		fr: "changez votre mot de passe",
 		de: "ändern Sie Ihr Passwort",
@@ -395,7 +395,7 @@ export const pageLabels = {
 	},
 	"banner.bootstrap.after": {
 		en: "before deploying to a live server.",
-		ar: "before deploying to a live server.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قبل النشر على خادم مباشر.",
 		es: "antes de desplegar a un servidor en vivo.",
 		fr: "avant tout déploiement en production.",
 		de: "bevor Sie auf einen Live-Server deployen.",
@@ -409,7 +409,7 @@ export const pageLabels = {
 	// ── Dashboard ────────────────────────────────────────────────────────────
 	"dashboard.description": {
 		en: "Editorial overview, page health, and admin queues.",
-		ar: "Editorial overview, page health, and admin queues.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نظرة عامة تحريرية، وصحّة الصفحات، وقوائم انتظار الإدارة.",
 		es: "Vista editorial, salud de páginas y colas de administración.",
 		fr: "Vue éditoriale, santé des pages et files d'administration.",
 		de: "Redaktionelle Übersicht, Seitenzustand und Admin-Warteschlangen.",
@@ -421,7 +421,7 @@ export const pageLabels = {
 	},
 	"dashboard.publishedPosts": {
 		en: "Published posts",
-		ar: "Published posts", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات المنشورة",
 		es: "Entradas publicadas",
 		fr: "Articles publiés",
 		de: "Veröffentlichte Beiträge",
@@ -433,7 +433,7 @@ export const pageLabels = {
 	},
 	"dashboard.publishedPostsDesc": {
 		en: "Blog posts currently live on the public site.",
-		ar: "Blog posts currently live on the public site.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منشورات المدوّنة الحالية على الموقع العام.",
 		es: "Entradas del blog actualmente publicadas en el sitio público.",
 		fr: "Articles de blog actuellement publiés sur le site public.",
 		de: "Blogbeiträge, die derzeit auf der öffentlichen Site live sind.",
@@ -445,7 +445,7 @@ export const pageLabels = {
 	},
 	"dashboard.publicPages": {
 		en: "Public pages",
-		ar: "Public pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات العامة",
 		es: "Páginas públicas",
 		fr: "Pages publiques",
 		de: "Öffentliche Seiten",
@@ -457,7 +457,7 @@ export const pageLabels = {
 	},
 	"dashboard.publicPagesDesc": {
 		en: "Legacy and route-backed public pages editable in admin.",
-		ar: "Legacy and route-backed public pages editable in admin.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات العامة القديمة والمستندة إلى مسار القابلة للتحرير في لوحة الإدارة.",
 		es: "Páginas públicas heredadas y de rutas editables en administración.",
 		fr: "Pages publiques héritées et basées sur les routes, modifiables dans l'administration.",
 		de: "Alte und routenbasierte öffentliche Seiten, im Admin bearbeitbar.",
@@ -469,7 +469,7 @@ export const pageLabels = {
 	},
 	"dashboard.needsReviewDesc": {
 		en: "Posts waiting for editorial attention.",
-		ar: "Posts waiting for editorial attention.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات التي تنتظر انتباهًا تحريريًا.",
 		es: "Entradas esperando atención editorial.",
 		fr: "Articles en attente d'attention éditoriale.",
 		de: "Beiträge, die redaktionelle Aufmerksamkeit benötigen.",
@@ -481,7 +481,7 @@ export const pageLabels = {
 	},
 	"dashboard.scheduledPosts": {
 		en: "Scheduled posts",
-		ar: "Scheduled posts", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات المجدوَلة",
 		es: "Entradas programadas",
 		fr: "Articles planifiés",
 		de: "Geplante Beiträge",
@@ -493,7 +493,7 @@ export const pageLabels = {
 	},
 	"dashboard.scheduledPostsDesc": {
 		en: "Upcoming blog posts with a future publish time.",
-		ar: "Upcoming blog posts with a future publish time.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منشورات المدوّنة القادمة بوقت نشر مستقبلي.",
 		es: "Próximas entradas con fecha de publicación futura.",
 		fr: "Articles à venir avec une date de publication future.",
 		de: "Kommende Blogbeiträge mit zukünftigem Veröffentlichungszeitpunkt.",
@@ -505,7 +505,7 @@ export const pageLabels = {
 	},
 	"dashboard.redirectRules": {
 		en: "Redirect rules",
-		ar: "Redirect rules", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قواعد إعادة التوجيه",
 		es: "Reglas de redirección",
 		fr: "Règles de redirection",
 		de: "Weiterleitungsregeln",
@@ -517,7 +517,7 @@ export const pageLabels = {
 	},
 	"dashboard.redirectRulesDesc": {
 		en: "Active redirects currently managed in admin.",
-		ar: "Active redirects currently managed in admin.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عمليات إعادة التوجيه النشطة المُدارة حاليًا في لوحة الإدارة.",
 		es: "Redirecciones activas actualmente gestionadas en administración.",
 		fr: "Redirections actives gérées dans l'administration.",
 		de: "Aktive Weiterleitungen, die im Admin verwaltet werden.",
@@ -529,7 +529,7 @@ export const pageLabels = {
 	},
 	"dashboard.translationFollowup": {
 		en: "Translation follow-up",
-		ar: "Translation follow-up", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "متابعة الترجمة",
 		es: "Seguimiento de traducciones",
 		fr: "Suivi des traductions",
 		de: "Übersetzungs-Nachverfolgung",
@@ -541,7 +541,7 @@ export const pageLabels = {
 	},
 	"dashboard.translationFollowupDesc": {
 		en: "Localized routes that still need attention before publication.",
-		ar: "Localized routes that still need attention before publication.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسارات المترجَمة التي لا تزال تحتاج إلى انتباه قبل النشر.",
 		es: "Rutas localizadas que aún requieren atención antes de publicar.",
 		fr: "Routes localisées nécessitant encore une intervention avant publication.",
 		de: "Lokalisierte Routen, die vor der Veröffentlichung noch Aufmerksamkeit benötigen.",
@@ -553,7 +553,7 @@ export const pageLabels = {
 	},
 	"dashboard.create": {
 		en: "Create",
-		ar: "Create", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إنشاء",
 		es: "Crear",
 		fr: "Créer",
 		de: "Erstellen",
@@ -565,7 +565,7 @@ export const pageLabels = {
 	},
 	"dashboard.startNewWork": {
 		en: "Start New Work",
-		ar: "Start New Work", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ابدأ عملًا جديدًا",
 		es: "Iniciar nuevo trabajo",
 		fr: "Démarrer un nouveau travail",
 		de: "Neue Arbeit starten",
@@ -577,7 +577,7 @@ export const pageLabels = {
 	},
 	"dashboard.startNewWorkDesc": {
 		en: "Create new content quickly, then use the sidebar for the full editing surfaces.",
-		ar: "Create new content quickly, then use the sidebar for the full editing surfaces.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أنشئ محتوى جديدًا سريعًا، ثم استخدم الشريط الجانبي لواجهات التحرير الكاملة.",
 		es: "Crea nuevo contenido rápidamente y usa la barra lateral para superficies de edición completas.",
 		fr: "Créez rapidement du nouveau contenu, puis utilisez la barre latérale pour l'édition complète.",
 		de: "Erstellen Sie schnell neue Inhalte und nutzen Sie die Seitenleiste für die vollständige Bearbeitung.",
@@ -589,7 +589,7 @@ export const pageLabels = {
 	},
 	"dashboard.newPost": {
 		en: "New post",
-		ar: "New post", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منشور جديد",
 		es: "Nueva entrada",
 		fr: "Nouvel article",
 		de: "Neuer Beitrag",
@@ -601,7 +601,7 @@ export const pageLabels = {
 	},
 	"dashboard.newPage": {
 		en: "New page",
-		ar: "New page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحة جديدة",
 		es: "Nueva página",
 		fr: "Nouvelle page",
 		de: "Neue Seite",
@@ -613,7 +613,7 @@ export const pageLabels = {
 	},
 	"dashboard.newAuthor": {
 		en: "New author",
-		ar: "New author", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مؤلف جديد",
 		es: "Nuevo autor",
 		fr: "Nouvel auteur",
 		de: "Neuer Autor",
@@ -625,7 +625,7 @@ export const pageLabels = {
 	},
 	"dashboard.newUser": {
 		en: "New user",
-		ar: "New user", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مستخدم جديد",
 		es: "Nuevo usuario",
 		fr: "Nouvel utilisateur",
 		de: "Neuer Benutzer",
@@ -637,7 +637,7 @@ export const pageLabels = {
 	},
 	"dashboard.supportSurfaces": {
 		en: "Support Surfaces",
-		ar: "Support Surfaces", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أسطح الدعم",
 		es: "Superficies de soporte",
 		fr: "Surfaces de support",
 		de: "Unterstützungsbereiche",
@@ -649,7 +649,7 @@ export const pageLabels = {
 	},
 	"dashboard.supportSurfacesDesc": {
 		en: "Metadata, route health, and system outputs.",
-		ar: "Metadata, route health, and system outputs.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البيانات الوصفية وصحة المسارات ومخرجات النظام.",
 		es: "Metadatos, salud de rutas y salidas del sistema.",
 		fr: "Métadonnées, santé des routes et sorties système.",
 		de: "Metadaten, Routenzustand und Systemausgaben.",
@@ -661,7 +661,7 @@ export const pageLabels = {
 	},
 	"dashboard.translations": {
 		en: "Translations",
-		ar: "Translations", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الترجمات",
 		es: "Traducciones",
 		fr: "Traductions",
 		de: "Übersetzungen",
@@ -673,7 +673,7 @@ export const pageLabels = {
 	},
 	"dashboard.translationsDesc": {
 		en: "Localized routes not yet published.",
-		ar: "Localized routes not yet published.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسارات المترجَمة التي لم تُنشر بعد.",
 		es: "Rutas localizadas aún no publicadas.",
 		fr: "Routes localisées non encore publiées.",
 		de: "Lokalisierte Routen, die noch nicht veröffentlicht sind.",
@@ -685,7 +685,7 @@ export const pageLabels = {
 	},
 	"dashboard.seo": {
 		en: "SEO",
-		ar: "SEO", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحسين محركات البحث",
 		es: "SEO",
 		fr: "SEO",
 		de: "SEO",
@@ -697,7 +697,7 @@ export const pageLabels = {
 	},
 	"dashboard.seoDesc": {
 		en: "Pages or routes missing dedicated metadata.",
-		ar: "Pages or routes missing dedicated metadata.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات أو المسارات التي تفتقر إلى بيانات وصفية مخصّصة.",
 		es: "Páginas o rutas sin metadatos dedicados.",
 		fr: "Pages ou routes sans métadonnées dédiées.",
 		de: "Seiten oder Routen ohne dedizierte Metadaten.",
@@ -709,7 +709,7 @@ export const pageLabels = {
 	},
 	"dashboard.archives": {
 		en: "Archives",
-		ar: "Archives", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الأرشيفات",
 		es: "Archivos",
 		fr: "Archives",
 		de: "Archive",
@@ -721,7 +721,7 @@ export const pageLabels = {
 	},
 	"dashboard.archivesDesc": {
 		en: "Archive landing pages with separate owner editors.",
-		ar: "Archive landing pages with separate owner editors.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحات هبوط الأرشيف مع محرّرين مالكين منفصلين.",
 		es: "Páginas de archivo con editores de propietario separados.",
 		fr: "Pages d'archives avec éditeurs propriétaires séparés.",
 		de: "Archiv-Landingpages mit separaten Eigentümer-Editoren.",
@@ -733,7 +733,7 @@ export const pageLabels = {
 	},
 	"dashboard.system": {
 		en: "System",
-		ar: "System", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النظام",
 		es: "Sistema",
 		fr: "Système",
 		de: "System",
@@ -745,7 +745,7 @@ export const pageLabels = {
 	},
 	"dashboard.systemDesc": {
 		en: "500 page and generated public outputs.",
-		ar: "500 page and generated public outputs.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحة 500 والمخرجات العامة المُولَّدة.",
 		es: "Página 500 y salidas públicas generadas.",
 		fr: "Page 500 et sorties publiques générées.",
 		de: "500-Seite und generierte öffentliche Ausgaben.",
@@ -757,7 +757,7 @@ export const pageLabels = {
 	},
 	"dashboard.queue": {
 		en: "Queue",
-		ar: "Queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة الانتظار",
 		es: "Cola",
 		fr: "File",
 		de: "Warteschlange",
@@ -769,7 +769,7 @@ export const pageLabels = {
 	},
 	"dashboard.scheduledSoon": {
 		en: "Scheduled Soon",
-		ar: "Scheduled Soon", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مجدوَل قريبًا",
 		es: "Programado pronto",
 		fr: "Bientôt planifié",
 		de: "Bald geplant",
@@ -781,7 +781,7 @@ export const pageLabels = {
 	},
 	"dashboard.scheduledSoonDesc": {
 		en: "The next posts queued to go live.",
-		ar: "The next posts queued to go live.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات التالية في قائمة الانتظار للنشر.",
 		es: "Las próximas entradas en cola para publicarse.",
 		fr: "Les prochains articles en file pour publication.",
 		de: "Die nächsten Beiträge in der Warteschlange zur Veröffentlichung.",
@@ -793,7 +793,7 @@ export const pageLabels = {
 	},
 	"dashboard.viewScheduled": {
 		en: "View scheduled",
-		ar: "View scheduled", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عرض المجدوَل",
 		es: "Ver programados",
 		fr: "Voir les planifiés",
 		de: "Geplante anzeigen",
@@ -805,7 +805,7 @@ export const pageLabels = {
 	},
 	"dashboard.noFutureScheduled": {
 		en: "No future scheduled posts are currently queued.",
-		ar: "No future scheduled posts are currently queued.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد منشورات مجدوَلة مستقبليًا في قائمة الانتظار حاليًا.",
 		es: "No hay entradas programadas en cola actualmente.",
 		fr: "Aucun article futur n'est actuellement planifié.",
 		de: "Derzeit sind keine zukünftig geplanten Beiträge in der Warteschlange.",
@@ -817,7 +817,7 @@ export const pageLabels = {
 	},
 	"dashboard.postReviewQueue": {
 		en: "Post Review Queue",
-		ar: "Post Review Queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة انتظار مراجعة المنشورات",
 		es: "Cola de revisión de entradas",
 		fr: "File de révision des articles",
 		de: "Beitrags-Prüfungswarteschlange",
@@ -829,7 +829,7 @@ export const pageLabels = {
 	},
 	"dashboard.postReviewQueueDesc": {
 		en: "Draft and review items waiting for an editor pass.",
-		ar: "Draft and review items waiting for an editor pass.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسودات وعناصر المراجعة بانتظار مرور المحرّر.",
 		es: "Borradores y elementos en revisión esperando una pasada del editor.",
 		fr: "Brouillons et éléments en révision en attente d'une revue éditeur.",
 		de: "Entwürfe und Prüfungselemente, die auf einen Editor-Durchgang warten.",
@@ -841,7 +841,7 @@ export const pageLabels = {
 	},
 	"dashboard.recentActivity": {
 		en: "Recent Activity",
-		ar: "Recent Activity", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النشاط الأخير",
 		es: "Actividad reciente",
 		fr: "Activité récente",
 		de: "Letzte Aktivitäten",
@@ -853,7 +853,7 @@ export const pageLabels = {
 	},
 	"dashboard.recentlyUpdated": {
 		en: "Recently Updated",
-		ar: "Recently Updated", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حُدِّث مؤخّرًا",
 		es: "Actualizado recientemente",
 		fr: "Récemment mis à jour",
 		de: "Kürzlich aktualisiert",
@@ -865,7 +865,7 @@ export const pageLabels = {
 	},
 	"dashboard.recentlyUpdatedDesc": {
 		en: "Recent changes with direct editor entry points.",
-		ar: "Recent changes with direct editor entry points.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التغييرات الأخيرة مع نقاط دخول مباشرة للمحرّر.",
 		es: "Cambios recientes con accesos directos al editor.",
 		fr: "Modifications récentes avec accès direct à l'éditeur.",
 		de: "Kürzliche Änderungen mit direkten Editor-Einstiegspunkten.",
@@ -877,7 +877,7 @@ export const pageLabels = {
 	},
 	"dashboard.publish": {
 		en: "Publish",
-		ar: "Publish", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نشر",
 		es: "Publicar",
 		fr: "Publier",
 		de: "Veröffentlichen",
@@ -889,7 +889,7 @@ export const pageLabels = {
 	},
 	"dashboard.latestDeployment": {
 		en: "Latest Deployment",
-		ar: "Latest Deployment", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "آخر نشر",
 		es: "Despliegue más reciente",
 		fr: "Dernier déploiement",
 		de: "Letztes Deployment",
@@ -901,7 +901,7 @@ export const pageLabels = {
 	},
 	"dashboard.latestDeploymentDesc": {
 		en: "Trusted record of the most recent build trigger sourced from the audit log.",
-		ar: "Trusted record of the most recent build trigger sourced from the audit log.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سجل موثوق لأحدث إطلاق بناء مأخوذ من سجل التدقيق.",
 		es: "Registro confiable del último disparador de compilación obtenido del registro de auditoría.",
 		fr: "Enregistrement fiable du dernier déclencheur de build issu du journal d'audit.",
 		de: "Vertrauenswürdiger Eintrag des letzten Build-Auslösers aus dem Audit-Protokoll.",
@@ -913,7 +913,7 @@ export const pageLabels = {
 	},
 	"dashboard.noPublishYet": {
 		en: "No publish has been triggered yet. Use the Publish button in the topbar to start a build.",
-		ar: "No publish has been triggered yet. Use the Publish button in the topbar to start a build.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'لم يُشغَّل النشر بعد. استخدم زر "نشر" في الشريط العلوي لبدء البناء.',
 		es: "Aún no se ha activado ninguna publicación. Usa el botón Publicar en la barra superior para iniciar una compilación.",
 		fr: "Aucune publication n'a encore été déclenchée. Utilisez le bouton Publier dans la barre supérieure pour lancer un build.",
 		de: "Bisher wurde keine Veröffentlichung ausgelöst. Nutzen Sie den Publish-Button in der oberen Leiste, um einen Build zu starten.",
@@ -926,7 +926,7 @@ export const pageLabels = {
 
 	"dashboard.descriptionEditor": {
 		en: "Editorial overview for blog posts, comments, and media work.",
-		ar: "Editorial overview for blog posts, comments, and media work.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نظرة عامة تحريرية على منشورات المدوّنة والتعليقات وأعمال الوسائط.",
 		es: "Vista editorial para entradas, comentarios y trabajo de medios.",
 		fr: "Vue éditoriale pour les articles, commentaires et travail média.",
 		de: "Redaktionelle Übersicht für Beiträge, Kommentare und Medienarbeit.",
@@ -938,7 +938,7 @@ export const pageLabels = {
 	},
 	"dashboard.pendingComments": {
 		en: "Pending comments",
-		ar: "Pending comments", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعليقات معلَّقة",
 		es: "Comentarios pendientes",
 		fr: "Commentaires en attente",
 		de: "Ausstehende Kommentare",
@@ -950,7 +950,7 @@ export const pageLabels = {
 	},
 	"dashboard.pendingCommentsDesc": {
 		en: "Comments still waiting for moderation.",
-		ar: "Comments still waiting for moderation.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التعليقات التي لا تزال بانتظار الإشراف.",
 		es: "Comentarios aún en espera de moderación.",
 		fr: "Commentaires en attente de modération.",
 		de: "Kommentare, die noch auf Moderation warten.",
@@ -962,7 +962,7 @@ export const pageLabels = {
 	},
 	"dashboard.editorialQueue": {
 		en: "Editorial Queue",
-		ar: "Editorial Queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة الانتظار التحريرية",
 		es: "Cola editorial",
 		fr: "File éditoriale",
 		de: "Redaktionswarteschlange",
@@ -974,7 +974,7 @@ export const pageLabels = {
 	},
 	"dashboard.open": {
 		en: "Open",
-		ar: "Open", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح",
 		es: "Abrir",
 		fr: "Ouvrir",
 		de: "Öffnen",
@@ -986,7 +986,7 @@ export const pageLabels = {
 	},
 	"dashboard.review": {
 		en: "Review",
-		ar: "Review", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مراجعة",
 		es: "Revisar",
 		fr: "Réviser",
 		de: "Prüfen",
@@ -998,7 +998,7 @@ export const pageLabels = {
 	},
 	"dashboard.nothingWaiting": {
 		en: "Nothing is currently waiting for editorial review.",
-		ar: "Nothing is currently waiting for editorial review.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يوجد حاليًا ما ينتظر مراجعة تحريرية.",
 		es: "Nada está actualmente en espera de revisión editorial.",
 		fr: "Rien n'est actuellement en attente de révision éditoriale.",
 		de: "Derzeit wartet nichts auf eine redaktionelle Prüfung.",
@@ -1010,7 +1010,7 @@ export const pageLabels = {
 	},
 	"dashboard.partialResults": {
 		en: "Some dashboard data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some dashboard data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات لوحة التحكم غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos del panel no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données du tableau de bord sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Dashboard-Daten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -1022,7 +1022,7 @@ export const pageLabels = {
 	},
 	"dashboard.deployNoRecord": {
 		en: "No publish recorded",
-		ar: "No publish recorded", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لم يُسجَّل نشر",
 		es: "Sin publicaciones registradas",
 		fr: "Aucune publication enregistrée",
 		de: "Keine Veröffentlichung erfasst",
@@ -1034,7 +1034,7 @@ export const pageLabels = {
 	},
 	"dashboard.deployTriggered": {
 		en: "Triggered",
-		ar: "Triggered", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أُطلق",
 		es: "Activado",
 		fr: "Déclenché",
 		de: "Ausgelöst",
@@ -1046,7 +1046,7 @@ export const pageLabels = {
 	},
 	"dashboard.deployFailed": {
 		en: "Failed",
-		ar: "Failed", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فشِل",
 		es: "Falló",
 		fr: "Échec",
 		de: "Fehlgeschlagen",
@@ -1058,7 +1058,7 @@ export const pageLabels = {
 	},
 	"dashboard.deployBy": {
 		en: "by",
-		ar: "by", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بواسطة",
 		es: "por",
 		fr: "par",
 		de: "von",
@@ -1070,7 +1070,7 @@ export const pageLabels = {
 	},
 	"common.unknownUpdateTime": {
 		en: "Unknown update time",
-		ar: "Unknown update time", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وقت التحديث غير معروف",
 		es: "Hora de actualización desconocida",
 		fr: "Heure de mise à jour inconnue",
 		de: "Aktualisierungszeit unbekannt",
@@ -1084,7 +1084,7 @@ export const pageLabels = {
 	// ── Posts list ──────────────────────────────────────────────────────────
 	"posts.description": {
 		en: "Published and draft blog posts managed through the post editor.",
-		ar: "Published and draft blog posts managed through the post editor.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات والمسودات المُدارة عبر محرّر المنشورات.",
 		es: "Entradas publicadas y en borrador gestionadas mediante el editor.",
 		fr: "Articles publiés et brouillons gérés via l'éditeur d'article.",
 		de: "Veröffentlichte und Entwurfs-Blogbeiträge, verwaltet über den Beitragseditor.",
@@ -1096,7 +1096,7 @@ export const pageLabels = {
 	},
 	"posts.partialResults": {
 		en: "Some post index data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some post index data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات فهرس المنشورات غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos del índice de entradas no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de l'index des articles sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Beitrags-Index-Daten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -1108,7 +1108,7 @@ export const pageLabels = {
 	},
 	"posts.openPublicBlog": {
 		en: "Open public blog",
-		ar: "Open public blog", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح المدوّنة العامة",
 		es: "Abrir blog público",
 		fr: "Ouvrir le blog public",
 		de: "Öffentliches Blog öffnen",
@@ -1120,7 +1120,7 @@ export const pageLabels = {
 	},
 	"posts.visiblePosts": {
 		en: "Visible posts",
-		ar: "Visible posts", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات الظاهرة",
 		es: "Entradas visibles",
 		fr: "Articles visibles",
 		de: "Sichtbare Beiträge",
@@ -1132,7 +1132,7 @@ export const pageLabels = {
 	},
 	"posts.visiblePostsDesc": {
 		en: "Posts in the current filtered view.",
-		ar: "Posts in the current filtered view.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات في العرض المصفَّى الحالي.",
 		es: "Entradas en la vista filtrada actual.",
 		fr: "Articles dans la vue filtrée actuelle.",
 		de: "Beiträge in der aktuell gefilterten Ansicht.",
@@ -1144,7 +1144,7 @@ export const pageLabels = {
 	},
 	"posts.reviewQueue": {
 		en: "Review queue",
-		ar: "Review queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة انتظار المراجعة",
 		es: "Cola de revisión",
 		fr: "File de révision",
 		de: "Prüfungswarteschlange",
@@ -1156,7 +1156,7 @@ export const pageLabels = {
 	},
 	"posts.reviewQueueDesc": {
 		en: "Draft and in-review posts waiting for editorial work.",
-		ar: "Draft and in-review posts waiting for editorial work.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسودات والمنشورات قيد المراجعة بانتظار العمل التحريري.",
 		es: "Entradas en borrador y revisión en espera de trabajo editorial.",
 		fr: "Articles en brouillon et en révision en attente de travail éditorial.",
 		de: "Entwurfs- und Prüfungsbeiträge, die auf redaktionelle Arbeit warten.",
@@ -1168,7 +1168,7 @@ export const pageLabels = {
 	},
 	"posts.workflow": {
 		en: "Post Workflow",
-		ar: "Post Workflow", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سير عمل المنشورات",
 		es: "Flujo de entradas",
 		fr: "Flux des articles",
 		de: "Beitragsablauf",
@@ -1180,7 +1180,7 @@ export const pageLabels = {
 	},
 	"posts.blogPostList": {
 		en: "Blog Post List",
-		ar: "Blog Post List", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة منشورات المدوّنة",
 		es: "Lista de entradas",
 		fr: "Liste des articles",
 		de: "Blogbeitragsliste",
@@ -1192,7 +1192,7 @@ export const pageLabels = {
 	},
 	"posts.searchOnce": {
 		en: "Search once, then narrow to the exact editorial slice you need.",
-		ar: "Search once, then narrow to the exact editorial slice you need.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ابحث مرة واحدة ثم ضيِّق إلى الشريحة التحريرية التي تحتاجها بالضبط.",
 		es: "Busca una vez y luego limita al fragmento editorial exacto que necesitas.",
 		fr: "Cherchez une fois, puis affinez à la tranche éditoriale exacte dont vous avez besoin.",
 		de: "Einmal suchen, dann auf den genauen redaktionellen Ausschnitt einschränken.",
@@ -1204,7 +1204,7 @@ export const pageLabels = {
 	},
 	"posts.searchPlaceholder": {
 		en: "Search title, slug, route, or assignment",
-		ar: "Search title, slug, route, or assignment", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ابحث بالعنوان أو المعرّف اللطيف أو المسار أو الإسناد",
 		es: "Buscar título, slug, ruta o asignación",
 		fr: "Rechercher titre, slug, route ou assignation",
 		de: "Titel, Slug, Route oder Zuweisung suchen",
@@ -1216,7 +1216,7 @@ export const pageLabels = {
 	},
 	"posts.searchPosts": {
 		en: "Search posts",
-		ar: "Search posts", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البحث في المنشورات",
 		es: "Buscar entradas",
 		fr: "Rechercher des articles",
 		de: "Beiträge suchen",
@@ -1228,7 +1228,7 @@ export const pageLabels = {
 	},
 	"posts.workflowFilter": {
 		en: "Workflow",
-		ar: "Workflow", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سير العمل",
 		es: "Flujo",
 		fr: "Flux",
 		de: "Ablauf",
@@ -1240,7 +1240,7 @@ export const pageLabels = {
 	},
 	"posts.allWorkflowStates": {
 		en: "All workflow states",
-		ar: "All workflow states", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل حالات سير العمل",
 		es: "Todos los estados de flujo",
 		fr: "Tous les états de flux",
 		de: "Alle Ablaufstatus",
@@ -1252,7 +1252,7 @@ export const pageLabels = {
 	},
 	"posts.tag": {
 		en: "Tag",
-		ar: "Tag", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وسم",
 		es: "Etiqueta",
 		fr: "Étiquette",
 		de: "Tag",
@@ -1264,7 +1264,7 @@ export const pageLabels = {
 	},
 	"posts.archiveFilter": {
 		en: "Archive filter:",
-		ar: "Archive filter:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مرشِّح الأرشيف:",
 		es: "Filtro de archivo:",
 		fr: "Filtre d'archive :",
 		de: "Archivfilter:",
@@ -1276,7 +1276,7 @@ export const pageLabels = {
 	},
 	"posts.matchedSummary": {
 		en: "{count} posts matched the current filters. Showing page {page} of {total}.",
-		ar: "{count} posts matched the current filters. Showing page {page} of {total}.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "{count} منشور طابق المرشّحات الحالية. عرض الصفحة {page} من {total}.",
 		es: "{count} entradas coincidieron con los filtros actuales. Mostrando página {page} de {total}.",
 		fr: "{count} articles correspondent aux filtres actuels. Page {page} sur {total}.",
 		de: "{count} Beiträge entsprechen den aktuellen Filtern. Seite {page} von {total}.",
@@ -1288,7 +1288,7 @@ export const pageLabels = {
 	},
 	"posts.contentFilters": {
 		en: "Content filters",
-		ar: "Content filters", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مرشّحات المحتوى",
 		es: "Filtros de contenido",
 		fr: "Filtres de contenu",
 		de: "Inhaltsfilter",
@@ -1300,7 +1300,7 @@ export const pageLabels = {
 	},
 	"posts.contentList": {
 		en: "Content list",
-		ar: "Content list", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة المحتوى",
 		es: "Lista de contenido",
 		fr: "Liste de contenu",
 		de: "Inhaltsliste",
@@ -1312,7 +1312,7 @@ export const pageLabels = {
 	},
 	"posts.tableScheduled": {
 		en: "Scheduled",
-		ar: "Scheduled", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مجدوَل",
 		es: "Programado",
 		fr: "Planifié",
 		de: "Geplant",
@@ -1324,7 +1324,7 @@ export const pageLabels = {
 	},
 	"posts.authors": {
 		en: "Authors",
-		ar: "Authors", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المؤلفون",
 		es: "Autores",
 		fr: "Auteurs",
 		de: "Autoren",
@@ -1336,7 +1336,7 @@ export const pageLabels = {
 	},
 	"posts.categories": {
 		en: "Categories",
-		ar: "Categories", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التصنيفات",
 		es: "Categorías",
 		fr: "Catégories",
 		de: "Kategorien",
@@ -1348,7 +1348,7 @@ export const pageLabels = {
 	},
 	"posts.noMatched": {
 		en: "No content records matched the current filters.",
-		ar: "No content records matched the current filters.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لم تطابِق أي سجلات محتوى المرشّحات الحالية.",
 		es: "Ningún registro de contenido coincidió con los filtros actuales.",
 		fr: "Aucun enregistrement de contenu ne correspond aux filtres actuels.",
 		de: "Keine Inhaltsdatensätze entsprechen den aktuellen Filtern.",
@@ -1360,7 +1360,7 @@ export const pageLabels = {
 	},
 	"posts.previous": {
 		en: "← Previous",
-		ar: "← Previous", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "← السابق",
 		es: "← Anterior",
 		fr: "← Précédent",
 		de: "← Zurück",
@@ -1372,7 +1372,7 @@ export const pageLabels = {
 	},
 	"posts.next": {
 		en: "Next →",
-		ar: "Next →", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التالي ←",
 		es: "Siguiente →",
 		fr: "Suivant →",
 		de: "Weiter →",
@@ -1384,7 +1384,7 @@ export const pageLabels = {
 	},
 	"posts.previousPage": {
 		en: "Previous page",
-		ar: "Previous page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحة السابقة",
 		es: "Página anterior",
 		fr: "Page précédente",
 		de: "Vorherige Seite",
@@ -1396,7 +1396,7 @@ export const pageLabels = {
 	},
 	"posts.nextPage": {
 		en: "Next page",
-		ar: "Next page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحة التالية",
 		es: "Siguiente página",
 		fr: "Page suivante",
 		de: "Nächste Seite",
@@ -1408,7 +1408,7 @@ export const pageLabels = {
 	},
 	"posts.pageOf": {
 		en: "Page {page} of {total}",
-		ar: "Page {page} of {total}", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحة {page} من {total}",
 		es: "Página {page} de {total}",
 		fr: "Page {page} sur {total}",
 		de: "Seite {page} von {total}",
@@ -1420,7 +1420,7 @@ export const pageLabels = {
 	},
 	"posts.pagination": {
 		en: "pagination",
-		ar: "pagination", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ترقيم الصفحات",
 		es: "paginación",
 		fr: "pagination",
 		de: "Seitennavigation",
@@ -1434,7 +1434,7 @@ export const pageLabels = {
 	// ── Pages list ──────────────────────────────────────────────────────────
 	"pages.description": {
 		en: "All human-facing public pages that are not blog posts.",
-		ar: "All human-facing public pages that are not blog posts.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل الصفحات العامة الموجَّهة للقراء التي ليست منشورات مدوّنة.",
 		es: "Todas las páginas públicas que no son entradas de blog.",
 		fr: "Toutes les pages publiques qui ne sont pas des articles de blog.",
 		de: "Alle öffentlichen Seiten, die keine Blogbeiträge sind.",
@@ -1446,7 +1446,7 @@ export const pageLabels = {
 	},
 	"pages.partialResults": {
 		en: "Some page index data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some page index data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات فهرس الصفحات غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos del índice de páginas no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de l'index des pages sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Seiten-Index-Daten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -1458,7 +1458,7 @@ export const pageLabels = {
 	},
 	"pages.openRouteTable": {
 		en: "Open route table",
-		ar: "Open route table", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح جدول المسارات",
 		es: "Abrir tabla de rutas",
 		fr: "Ouvrir la table des routes",
 		de: "Routentabelle öffnen",
@@ -1470,7 +1470,7 @@ export const pageLabels = {
 	},
 	"pages.allPages": {
 		en: "All pages",
-		ar: "All pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل الصفحات",
 		es: "Todas las páginas",
 		fr: "Toutes les pages",
 		de: "Alle Seiten",
@@ -1482,7 +1482,7 @@ export const pageLabels = {
 	},
 	"pages.allPagesDesc": {
 		en: "Public HTML pages currently managed through admin.",
-		ar: "Public HTML pages currently managed through admin.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحات HTML العامة المُدارة حاليًا عبر لوحة الإدارة.",
 		es: "Páginas HTML públicas gestionadas actualmente desde administración.",
 		fr: "Pages HTML publiques actuellement gérées via l'administration.",
 		de: "Öffentliche HTML-Seiten, derzeit über das Admin verwaltet.",
@@ -1494,7 +1494,7 @@ export const pageLabels = {
 	},
 	"pages.structuredPages": {
 		en: "Structured pages",
-		ar: "Structured pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات المنظَّمة",
 		es: "Páginas estructuradas",
 		fr: "Pages structurées",
 		de: "Strukturierte Seiten",
@@ -1506,7 +1506,7 @@ export const pageLabels = {
 	},
 	"pages.structuredPagesDesc": {
 		en: "Route-backed pages that use the structured page system.",
-		ar: "Route-backed pages that use the structured page system.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات المستندة إلى مسار التي تستخدم نظام الصفحات المنظَّمة.",
 		es: "Páginas basadas en rutas que usan el sistema de páginas estructuradas.",
 		fr: "Pages basées sur des routes utilisant le système de pages structurées.",
 		de: "Routenbasierte Seiten, die das strukturierte Seitensystem verwenden.",
@@ -1518,7 +1518,7 @@ export const pageLabels = {
 	},
 	"pages.publicPageOwnership": {
 		en: "Public Page Ownership",
-		ar: "Public Page Ownership", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملكية الصفحات العامة",
 		es: "Propiedad de páginas públicas",
 		fr: "Propriété des pages publiques",
 		de: "Eigentümerschaft öffentlicher Seiten",
@@ -1530,7 +1530,7 @@ export const pageLabels = {
 	},
 	"pages.pageIndex": {
 		en: "Page Index",
-		ar: "Page Index", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فهرس الصفحات",
 		es: "Índice de páginas",
 		fr: "Index des pages",
 		de: "Seitenindex",
@@ -1542,7 +1542,7 @@ export const pageLabels = {
 	},
 	"pages.useThisIndex": {
 		en: "Use this index to manage public pages. Open Route Table only when you need technical route details.",
-		ar: "Use this index to manage public pages. Open Route Table only when you need technical route details.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استخدِم هذا الفهرس لإدارة الصفحات العامة. افتح جدول المسارات فقط عند الحاجة إلى تفاصيل فنية.",
 		es: "Usa este índice para gestionar páginas públicas. Abre la tabla de rutas solo cuando necesites detalles técnicos.",
 		fr: "Utilisez cet index pour gérer les pages publiques. Ouvrez la table des routes uniquement pour les détails techniques.",
 		de: "Verwenden Sie diesen Index, um öffentliche Seiten zu verwalten. Öffnen Sie die Routentabelle nur für technische Details.",
@@ -1554,7 +1554,7 @@ export const pageLabels = {
 	},
 	"pages.structuredExplanation": {
 		en: "Structured pages are route-backed pages assembled from reusable content sections instead of one imported HTML body. They power pages like home, about, donate, and service landing pages.",
-		ar: "Structured pages are route-backed pages assembled from reusable content sections instead of one imported HTML body. They power pages like home, about, donate, and service landing pages.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات المنظَّمة هي صفحات مستندة إلى مسار مكوَّنة من أقسام محتوى قابلة لإعادة الاستخدام بدلًا من جسم HTML مستورَد واحد. تشغِّل صفحات مثل الرئيسية وعن وتبرّع وصفحات هبوط الخدمات.",
 		es: "Las páginas estructuradas son páginas basadas en rutas formadas por secciones de contenido reutilizables en lugar de un solo cuerpo HTML importado. Impulsan páginas como inicio, acerca, donar y páginas de servicio.",
 		fr: "Les pages structurées sont des pages basées sur des routes assemblées à partir de sections de contenu réutilisables au lieu d'un seul corps HTML importé. Elles alimentent des pages telles que l'accueil, à propos, faire un don et les pages de service.",
 		de: "Strukturierte Seiten sind routenbasierte Seiten, die aus wiederverwendbaren Inhaltsabschnitten statt aus einem importierten HTML-Body zusammengesetzt werden. Sie betreiben Seiten wie Startseite, Über, Spenden und Service-Landingpages.",
@@ -1566,7 +1566,7 @@ export const pageLabels = {
 	},
 	"pages.pageTypesInList": {
 		en: "Page types in this list",
-		ar: "Page types in this list", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أنواع الصفحات في هذه القائمة",
 		es: "Tipos de página en esta lista",
 		fr: "Types de page dans cette liste",
 		de: "Seitentypen in dieser Liste",
@@ -1578,7 +1578,7 @@ export const pageLabels = {
 	},
 	"pages.kindLegacy": {
 		en: "Legacy",
-		ar: "Legacy", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قديم",
 		es: "Heredada",
 		fr: "Héritée",
 		de: "Alt",
@@ -1590,7 +1590,7 @@ export const pageLabels = {
 	},
 	"pages.kindStructured": {
 		en: "Structured",
-		ar: "Structured", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منظَّم",
 		es: "Estructurada",
 		fr: "Structurée",
 		de: "Strukturiert",
@@ -1602,7 +1602,7 @@ export const pageLabels = {
 	},
 	"pages.kindArchive": {
 		en: "Archive",
-		ar: "Archive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أرشفة",
 		es: "Archivo",
 		fr: "Archive",
 		de: "Archiv",
@@ -1614,7 +1614,7 @@ export const pageLabels = {
 	},
 	"pages.legacyExplanation": {
 		en: "pages come from imported content.",
-		ar: "pages come from imported content.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تأتي الصفحات من محتوى مستورَد.",
 		es: "páginas provienen de contenido importado.",
 		fr: "pages proviennent de contenu importé.",
 		de: "Seiten stammen aus importiertem Inhalt.",
@@ -1626,7 +1626,7 @@ export const pageLabels = {
 	},
 	"pages.structuredExplanation2": {
 		en: "pages use reusable sections.",
-		ar: "pages use reusable sections.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تستخدم الصفحات أقسامًا قابلة لإعادة الاستخدام.",
 		es: "páginas usan secciones reutilizables.",
 		fr: "pages utilisent des sections réutilisables.",
 		de: "Seiten verwenden wiederverwendbare Abschnitte.",
@@ -1638,7 +1638,7 @@ export const pageLabels = {
 	},
 	"pages.archiveExplanation": {
 		en: "pages are listing routes such as author, category, and tag archives.",
-		ar: "pages are listing routes such as author, category, and tag archives.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات مسارات قوائم مثل أرشيفات المؤلفين والتصنيفات والوسوم.",
 		es: "páginas son rutas de listado como archivos de autor, categoría y etiquetas.",
 		fr: "pages sont des routes de listage comme les archives d'auteur, de catégorie et d'étiquette.",
 		de: "Seiten sind Listen-Routen wie Autoren-, Kategorie- und Tag-Archive.",
@@ -1650,7 +1650,7 @@ export const pageLabels = {
 	},
 	"pages.ofPagesSummary": {
 		en: "{filtered} of {total} public pages",
-		ar: "{filtered} of {total} public pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "{filtered} من {total} صفحة عامة",
 		es: "{filtered} de {total} páginas públicas",
 		fr: "{filtered} sur {total} pages publiques",
 		de: "{filtered} von {total} öffentlichen Seiten",
@@ -1662,7 +1662,7 @@ export const pageLabels = {
 	},
 	"pages.searchPages": {
 		en: "Search pages",
-		ar: "Search pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البحث في الصفحات",
 		es: "Buscar páginas",
 		fr: "Rechercher des pages",
 		de: "Seiten suchen",
@@ -1674,7 +1674,7 @@ export const pageLabels = {
 	},
 	"pages.searchPlaceholder": {
 		en: "Search title or path",
-		ar: "Search title or path", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ابحث بالعنوان أو المسار",
 		es: "Buscar título o ruta",
 		fr: "Rechercher titre ou chemin",
 		de: "Titel oder Pfad suchen",
@@ -1686,7 +1686,7 @@ export const pageLabels = {
 	},
 	"pages.filterByKind": {
 		en: "Filter by page kind",
-		ar: "Filter by page kind", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تصفية حسب نوع الصفحة",
 		es: "Filtrar por tipo de página",
 		fr: "Filtrer par type de page",
 		de: "Nach Seitentyp filtern",
@@ -1698,7 +1698,7 @@ export const pageLabels = {
 	},
 	"pages.filterByKindAria": {
 		en: "Filter pages by kind",
-		ar: "Filter pages by kind", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تصفية الصفحات حسب النوع",
 		es: "Filtrar páginas por tipo",
 		fr: "Filtrer les pages par type",
 		de: "Seiten nach Typ filtern",
@@ -1710,7 +1710,7 @@ export const pageLabels = {
 	},
 	"pages.allKinds": {
 		en: "All kinds",
-		ar: "All kinds", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل الأنواع",
 		es: "Todos los tipos",
 		fr: "Tous les types",
 		de: "Alle Typen",
@@ -1722,7 +1722,7 @@ export const pageLabels = {
 	},
 	"pages.kind": {
 		en: "Kind",
-		ar: "Kind", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النوع",
 		es: "Tipo",
 		fr: "Type",
 		de: "Typ",
@@ -1734,7 +1734,7 @@ export const pageLabels = {
 	},
 	"pages.pagesList": {
 		en: "Pages list",
-		ar: "Pages list", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة الصفحات",
 		es: "Lista de páginas",
 		fr: "Liste des pages",
 		de: "Seitenliste",
@@ -1746,7 +1746,7 @@ export const pageLabels = {
 	},
 	"pages.noMatch": {
 		en: "No pages match the current filters.",
-		ar: "No pages match the current filters.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد صفحات تطابِق المرشّحات الحالية.",
 		es: "Ninguna página coincide con los filtros actuales.",
 		fr: "Aucune page ne correspond aux filtres actuels.",
 		de: "Keine Seiten entsprechen den aktuellen Filtern.",
@@ -1758,7 +1758,7 @@ export const pageLabels = {
 	},
 	"pages.noMatchOr": {
 		en: "or",
-		ar: "or", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أو",
 		es: "o",
 		fr: "ou",
 		de: "oder",
@@ -1770,7 +1770,7 @@ export const pageLabels = {
 	},
 	"pages.createNewPage": {
 		en: "create a new page",
-		ar: "create a new page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أنشئ صفحة جديدة",
 		es: "crear una nueva página",
 		fr: "créer une nouvelle page",
 		de: "neue Seite erstellen",
@@ -1782,7 +1782,7 @@ export const pageLabels = {
 	},
 	"pages.editArchive": {
 		en: "Edit archive",
-		ar: "Edit archive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل الأرشيف",
 		es: "Editar archivo",
 		fr: "Modifier l'archive",
 		de: "Archiv bearbeiten",
@@ -1794,7 +1794,7 @@ export const pageLabels = {
 	},
 	"pages.editPageRow": {
 		en: "Edit page",
-		ar: "Edit page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل الصفحة",
 		es: "Editar página",
 		fr: "Modifier la page",
 		de: "Seite bearbeiten",
@@ -1806,7 +1806,7 @@ export const pageLabels = {
 	},
 	"pages.editRoutePage": {
 		en: "Edit route page",
-		ar: "Edit route page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل صفحة المسار",
 		es: "Editar página de ruta",
 		fr: "Modifier la page de route",
 		de: "Routenseite bearbeiten",
@@ -1818,7 +1818,7 @@ export const pageLabels = {
 	},
 	"pages.openPage": {
 		en: "Open page",
-		ar: "Open page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح الصفحة",
 		es: "Abrir página",
 		fr: "Ouvrir la page",
 		de: "Seite öffnen",
@@ -1830,7 +1830,7 @@ export const pageLabels = {
 	},
 	"pages.seeded": {
 		en: "Seeded",
-		ar: "Seeded", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مزروع",
 		es: "Sembrado",
 		fr: "Initialisé",
 		de: "Vorinstalliert",
@@ -1842,7 +1842,7 @@ export const pageLabels = {
 	},
 	"pages.forbidden.description": {
 		en: "This action requires an admin account.",
-		ar: "This action requires an admin account.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول.",
 		es: "Esta acción requiere una cuenta de administración.",
 		fr: "Cette action nécessite un compte administrateur.",
 		de: "Diese Aktion erfordert ein Admin-Konto.",
@@ -1854,7 +1854,7 @@ export const pageLabels = {
 	},
 	"pages.forbidden.body": {
 		en: "This action requires an admin account and is hidden from editor-only roles.",
-		ar: "This action requires an admin account and is hidden from editor-only roles.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول وهو مخفي عن الأدوار المحرّرة فقط.",
 		es: "Esta acción requiere una cuenta de administración y está oculta para roles solo de editor.",
 		fr: "Cette action nécessite un compte administrateur et est masquée pour les rôles éditeur uniquement.",
 		de: "Diese Aktion erfordert ein Admin-Konto und ist für reine Editor-Rollen ausgeblendet.",
@@ -1868,7 +1868,7 @@ export const pageLabels = {
 	// ── Media library ───────────────────────────────────────────────────────
 	"media.description": {
 		en: "Media management with familiar grid and list affordances.",
-		ar: "Media management with familiar grid and list affordances.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إدارة الوسائط مع عناصر تحكّم مألوفة في الشبكة والقائمة.",
 		es: "Gestión de medios con vista en cuadrícula y lista familiares.",
 		fr: "Gestion des médias avec affichages en grille et en liste familiers.",
 		de: "Medienverwaltung mit vertrauten Raster- und Listenansichten.",
@@ -1880,7 +1880,7 @@ export const pageLabels = {
 	},
 	"media.partialResults": {
 		en: "Some media data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some media data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات الوسائط غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de medios no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données médias sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Mediendaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -1892,7 +1892,7 @@ export const pageLabels = {
 	},
 	"media.savedSuccess": {
 		en: "The media library was updated successfully.",
-		ar: "The media library was updated successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تحديث مكتبة الوسائط بنجاح.",
 		es: "La biblioteca de medios se actualizó correctamente.",
 		fr: "La bibliothèque média a été mise à jour avec succès.",
 		de: "Die Medienbibliothek wurde erfolgreich aktualisiert.",
@@ -1904,7 +1904,7 @@ export const pageLabels = {
 	},
 	"media.deletedSuccess": {
 		en: "The media asset was deleted successfully.",
-		ar: "The media asset was deleted successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حذف عنصر الوسائط بنجاح.",
 		es: "El recurso de medios se eliminó correctamente.",
 		fr: "Le média a été supprimé avec succès.",
 		de: "Das Medien-Asset wurde erfolgreich gelöscht.",
@@ -1916,7 +1916,7 @@ export const pageLabels = {
 	},
 	"media.totalAssets": {
 		en: "Total assets",
-		ar: "Total assets", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجمالي العناصر",
 		es: "Recursos totales",
 		fr: "Total des médias",
 		de: "Gesamte Assets",
@@ -1928,7 +1928,7 @@ export const pageLabels = {
 	},
 	"media.totalAssetsDesc": {
 		en: "Images currently available in the media library.",
-		ar: "Images currently available in the media library.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصور المتاحة حاليًا في مكتبة الوسائط.",
 		es: "Imágenes actualmente disponibles en la biblioteca de medios.",
 		fr: "Images actuellement disponibles dans la bibliothèque médias.",
 		de: "Bilder, die derzeit in der Medienbibliothek verfügbar sind.",
@@ -1940,7 +1940,7 @@ export const pageLabels = {
 	},
 	"media.missingAlt": {
 		en: "Missing alt text",
-		ar: "Missing alt text", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نص بديل مفقود",
 		es: "Falta texto alternativo",
 		fr: "Texte alternatif manquant",
 		de: "Alternativtext fehlt",
@@ -1952,7 +1952,7 @@ export const pageLabels = {
 	},
 	"media.missingAltDesc": {
 		en: "Assets that still need accessible alternative text.",
-		ar: "Assets that still need accessible alternative text.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العناصر التي لا تزال بحاجة إلى نص بديل يسهل الوصول إليه.",
 		es: "Recursos que aún necesitan texto alternativo accesible.",
 		fr: "Médias qui ont encore besoin d'un texte alternatif accessible.",
 		de: "Assets, die noch zugänglichen Alternativtext benötigen.",
@@ -1964,7 +1964,7 @@ export const pageLabels = {
 	},
 	"media.addAssets": {
 		en: "Add Assets",
-		ar: "Add Assets", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إضافة عناصر",
 		es: "Añadir recursos",
 		fr: "Ajouter des médias",
 		de: "Assets hinzufügen",
@@ -1976,7 +1976,7 @@ export const pageLabels = {
 	},
 	"media.uploadMedia": {
 		en: "Upload Media",
-		ar: "Upload Media", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رفع الوسائط",
 		es: "Subir medios",
 		fr: "Téléverser un média",
 		de: "Medien hochladen",
@@ -1988,7 +1988,7 @@ export const pageLabels = {
 	},
 	"media.uploadDesc": {
 		en: "Add a new image asset, then update its title and alt text from the asset table below.",
-		ar: "Add a new image asset, then update its title and alt text from the asset table below.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أضِف صورة جديدة ثم حدّث عنوانها ونصها البديل من جدول العناصر أدناه.",
 		es: "Agrega un nuevo recurso de imagen y luego actualiza su título y texto alternativo en la tabla siguiente.",
 		fr: "Ajoutez un nouveau média image, puis mettez à jour son titre et son texte alternatif dans le tableau ci-dessous.",
 		de: "Fügen Sie ein neues Bild-Asset hinzu und aktualisieren Sie Titel und Alt-Text in der Tabelle unten.",
@@ -2000,7 +2000,7 @@ export const pageLabels = {
 	},
 	"media.file": {
 		en: "File",
-		ar: "File", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملف",
 		es: "Archivo",
 		fr: "Fichier",
 		de: "Datei",
@@ -2012,7 +2012,7 @@ export const pageLabels = {
 	},
 	"media.altText": {
 		en: "Alt text",
-		ar: "Alt text", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النص البديل",
 		es: "Texto alternativo",
 		fr: "Texte alternatif",
 		de: "Alternativtext",
@@ -2024,7 +2024,7 @@ export const pageLabels = {
 	},
 	"media.uploadButton": {
 		en: "Upload media",
-		ar: "Upload media", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رفع الوسائط",
 		es: "Subir medios",
 		fr: "Téléverser",
 		de: "Medien hochladen",
@@ -2036,7 +2036,7 @@ export const pageLabels = {
 	},
 	"media.uploading": {
 		en: "Uploading file...",
-		ar: "Uploading file...", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جارٍ رفع الملف...",
 		es: "Subiendo archivo...",
 		fr: "Téléversement…",
 		de: "Datei wird hochgeladen…",
@@ -2048,7 +2048,7 @@ export const pageLabels = {
 	},
 	"media.browse": {
 		en: "Browse",
-		ar: "Browse", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تصفّح",
 		es: "Explorar",
 		fr: "Parcourir",
 		de: "Durchsuchen",
@@ -2060,7 +2060,7 @@ export const pageLabels = {
 	},
 	"media.libraryGrid": {
 		en: "Library Grid",
-		ar: "Library Grid", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "شبكة المكتبة",
 		es: "Cuadrícula de la biblioteca",
 		fr: "Grille de la bibliothèque",
 		de: "Bibliotheksraster",
@@ -2072,7 +2072,7 @@ export const pageLabels = {
 	},
 	"media.libraryGridDesc": {
 		en: "Quick scan of current assets and the filenames editors are most likely to recognize.",
-		ar: "Quick scan of current assets and the filenames editors are most likely to recognize.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسح سريع للعناصر الحالية وأسماء الملفات التي يُرجَّح أن يتعرّف عليها المحرّرون.",
 		es: "Vista rápida de los recursos actuales y los nombres de archivo que los editores reconocerán.",
 		fr: "Aperçu rapide des médias actuels et des noms de fichier que les éditeurs reconnaissent.",
 		de: "Schneller Überblick über aktuelle Assets und Dateinamen, die Editoren am ehesten erkennen.",
@@ -2084,7 +2084,7 @@ export const pageLabels = {
 	},
 	"media.noAssets": {
 		en: "No media assets yet. Use the upload form above to add images.",
-		ar: "No media assets yet. Use the upload form above to add images.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد عناصر وسائط بعد. استخدِم نموذج الرفع أعلاه لإضافة صور.",
 		es: "Aún no hay recursos de medios. Usa el formulario de arriba para añadir imágenes.",
 		fr: "Aucun média pour le moment. Utilisez le formulaire ci-dessus pour ajouter des images.",
 		de: "Noch keine Medien-Assets. Verwenden Sie das Formular oben, um Bilder hinzuzufügen.",
@@ -2096,7 +2096,7 @@ export const pageLabels = {
 	},
 	"media.metadata": {
 		en: "Metadata",
-		ar: "Metadata", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البيانات الوصفية",
 		es: "Metadatos",
 		fr: "Métadonnées",
 		de: "Metadaten",
@@ -2108,7 +2108,7 @@ export const pageLabels = {
 	},
 	"media.libraryList": {
 		en: "Library List",
-		ar: "Library List", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة المكتبة",
 		es: "Lista de la biblioteca",
 		fr: "Liste de la bibliothèque",
 		de: "Bibliotheksliste",
@@ -2120,7 +2120,7 @@ export const pageLabels = {
 	},
 	"media.libraryListDesc": {
 		en: "Update metadata and remove assets from the detailed asset table below.",
-		ar: "Update metadata and remove assets from the detailed asset table below.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حدِّث البيانات الوصفية وأزل العناصر من جدول العناصر التفصيلي أدناه.",
 		es: "Actualiza metadatos y elimina recursos desde la tabla detallada de abajo.",
 		fr: "Mettez à jour les métadonnées et supprimez les médias depuis le tableau détaillé ci-dessous.",
 		de: "Aktualisieren Sie Metadaten und entfernen Sie Assets aus der detaillierten Tabelle unten.",
@@ -2132,7 +2132,7 @@ export const pageLabels = {
 	},
 	"media.preview": {
 		en: "Preview",
-		ar: "Preview", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "معاينة",
 		es: "Vista previa",
 		fr: "Aperçu",
 		de: "Vorschau",
@@ -2144,7 +2144,7 @@ export const pageLabels = {
 	},
 	"media.titleAlt": {
 		en: "Title / Alt",
-		ar: "Title / Alt", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العنوان / النص البديل",
 		es: "Título / Alt",
 		fr: "Titre / Alt",
 		de: "Titel / Alt",
@@ -2156,7 +2156,7 @@ export const pageLabels = {
 	},
 	"media.localPath": {
 		en: "Local Path",
-		ar: "Local Path", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسار المحلي",
 		es: "Ruta local",
 		fr: "Chemin local",
 		de: "Lokaler Pfad",
@@ -2168,7 +2168,7 @@ export const pageLabels = {
 	},
 	"media.r2Key": {
 		en: "R2 Key",
-		ar: "R2 Key", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مفتاح R2",
 		es: "Clave R2",
 		fr: "Clé R2",
 		de: "R2-Schlüssel",
@@ -2180,7 +2180,7 @@ export const pageLabels = {
 	},
 	"media.sourceUrl": {
 		en: "Source URL",
-		ar: "Source URL", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط المصدر",
 		es: "URL de origen",
 		fr: "URL source",
 		de: "Quell-URL",
@@ -2192,7 +2192,7 @@ export const pageLabels = {
 	},
 	"media.noAlt": {
 		en: "No alt text yet",
-		ar: "No alt text yet", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يوجد نص بديل بعد",
 		es: "Sin texto alternativo",
 		fr: "Aucun texte alternatif",
 		de: "Noch kein Alt-Text",
@@ -2204,7 +2204,7 @@ export const pageLabels = {
 	},
 	"media.saveMetadata": {
 		en: "Save metadata",
-		ar: "Save metadata", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ البيانات الوصفية",
 		es: "Guardar metadatos",
 		fr: "Enregistrer les métadonnées",
 		de: "Metadaten speichern",
@@ -2216,7 +2216,7 @@ export const pageLabels = {
 	},
 	"media.delete": {
 		en: "Delete",
-		ar: "Delete", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف",
 		es: "Eliminar",
 		fr: "Supprimer",
 		de: "Löschen",
@@ -2228,7 +2228,7 @@ export const pageLabels = {
 	},
 	"media.deleteDialogTitle": {
 		en: "Delete media asset?",
-		ar: "Delete media asset?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف عنصر الوسائط؟",
 		es: "¿Eliminar el recurso de medios?",
 		fr: "Supprimer ce média ?",
 		de: "Medien-Asset löschen?",
@@ -2240,7 +2240,7 @@ export const pageLabels = {
 	},
 	"media.deleteDialogBody": {
 		en: "Are you sure you want to delete this media asset?",
-		ar: "Are you sure you want to delete this media asset?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد حذف عنصر الوسائط هذا؟",
 		es: "¿Seguro que quieres eliminar este recurso de medios?",
 		fr: "Voulez-vous vraiment supprimer ce média ?",
 		de: "Möchten Sie dieses Medien-Asset wirklich löschen?",
@@ -2252,7 +2252,7 @@ export const pageLabels = {
 	},
 	"media.deleteWarning": {
 		en: "This action cannot be undone.",
-		ar: "This action cannot be undone.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يمكن التراجع عن هذا الإجراء.",
 		es: "Esta acción no se puede deshacer.",
 		fr: "Cette action est irréversible.",
 		de: "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -2264,7 +2264,7 @@ export const pageLabels = {
 	},
 	"media.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -2276,7 +2276,7 @@ export const pageLabels = {
 	},
 	"media.deleteAsset": {
 		en: "Delete Asset",
-		ar: "Delete Asset", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف العنصر",
 		es: "Eliminar recurso",
 		fr: "Supprimer le média",
 		de: "Asset löschen",
@@ -2288,7 +2288,7 @@ export const pageLabels = {
 	},
 	"media.assets": {
 		en: "Media assets",
-		ar: "Media assets", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عناصر الوسائط",
 		es: "Recursos de medios",
 		fr: "Médias",
 		de: "Medien-Assets",
@@ -2300,7 +2300,7 @@ export const pageLabels = {
 	},
 	"media.id": {
 		en: "ID",
-		ar: "ID", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف",
 		es: "ID",
 		fr: "ID",
 		de: "ID",
@@ -2312,7 +2312,7 @@ export const pageLabels = {
 	},
 	"media.fileAria": {
 		en: "Media file",
-		ar: "Media file", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملف الوسائط",
 		es: "Archivo de medios",
 		fr: "Fichier média",
 		de: "Mediendatei",
@@ -2324,7 +2324,7 @@ export const pageLabels = {
 	},
 	"media.titleAria": {
 		en: "Media title",
-		ar: "Media title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عنوان عنصر الوسائط",
 		es: "Título del medio",
 		fr: "Titre du média",
 		de: "Medien-Titel",
@@ -2336,7 +2336,7 @@ export const pageLabels = {
 	},
 	"media.altAria": {
 		en: "Media alt text",
-		ar: "Media alt text", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النص البديل للوسائط",
 		es: "Texto alternativo del medio",
 		fr: "Texte alternatif du média",
 		de: "Medien-Alternativtext",
@@ -2348,7 +2348,7 @@ export const pageLabels = {
 	},
 	"media.fileRequired": {
 		en: "Please select an image file",
-		ar: "Please select an image file", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يرجى اختيار ملف صورة",
 		es: "Selecciona un archivo de imagen",
 		fr: "Veuillez sélectionner un fichier image",
 		de: "Bitte wählen Sie eine Bilddatei aus",
@@ -2362,7 +2362,7 @@ export const pageLabels = {
 	// ── Comments ────────────────────────────────────────────────────────────
 	"comments.description": {
 		en: "Moderate pending, approved, and rejected comment records.",
-		ar: "Moderate pending, approved, and rejected comment records.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أشرف على سجلات التعليقات المعلَّقة والمعتمَدة والمرفوضة.",
 		es: "Modera comentarios pendientes, aprobados y rechazados.",
 		fr: "Modérez les commentaires en attente, approuvés et rejetés.",
 		de: "Moderieren Sie ausstehende, genehmigte und abgelehnte Kommentare.",
@@ -2374,7 +2374,7 @@ export const pageLabels = {
 	},
 	"comments.partialResults": {
 		en: "Some comment data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some comment data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات التعليقات غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de comentarios no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de commentaire sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Kommentardaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -2386,7 +2386,7 @@ export const pageLabels = {
 	},
 	"comments.savedSuccess": {
 		en: "The comment moderation state was updated successfully.",
-		ar: "The comment moderation state was updated successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تحديث حالة الإشراف على التعليق بنجاح.",
 		es: "El estado de moderación del comentario se actualizó correctamente.",
 		fr: "L'état de modération du commentaire a été mis à jour avec succès.",
 		de: "Der Moderationsstatus des Kommentars wurde erfolgreich aktualisiert.",
@@ -2398,7 +2398,7 @@ export const pageLabels = {
 	},
 	"comments.totalComments": {
 		en: "Total comments",
-		ar: "Total comments", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجمالي التعليقات",
 		es: "Comentarios totales",
 		fr: "Total des commentaires",
 		de: "Gesamtzahl Kommentare",
@@ -2410,7 +2410,7 @@ export const pageLabels = {
 	},
 	"comments.totalCommentsDesc": {
 		en: "Comment records currently available for moderation.",
-		ar: "Comment records currently available for moderation.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سجلات التعليقات المتاحة حاليًا للإشراف.",
 		es: "Registros de comentarios actualmente disponibles para moderación.",
 		fr: "Enregistrements de commentaires actuellement disponibles pour modération.",
 		de: "Kommentardatensätze, die derzeit zur Moderation verfügbar sind.",
@@ -2422,7 +2422,7 @@ export const pageLabels = {
 	},
 	"comments.pendingReview": {
 		en: "Pending review",
-		ar: "Pending review", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بانتظار المراجعة",
 		es: "Pendiente de revisión",
 		fr: "En attente de révision",
 		de: "Ausstehende Prüfung",
@@ -2434,7 +2434,7 @@ export const pageLabels = {
 	},
 	"comments.pendingReviewDesc": {
 		en: "Comments still waiting for an explicit moderation decision.",
-		ar: "Comments still waiting for an explicit moderation decision.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التعليقات التي لا تزال بانتظار قرار إشرافي صريح.",
 		es: "Comentarios aún en espera de una decisión explícita de moderación.",
 		fr: "Commentaires en attente d'une décision de modération explicite.",
 		de: "Kommentare, die noch auf eine ausdrückliche Moderationsentscheidung warten.",
@@ -2446,7 +2446,7 @@ export const pageLabels = {
 	},
 	"comments.moderation": {
 		en: "Moderation",
-		ar: "Moderation", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإشراف",
 		es: "Moderación",
 		fr: "Modération",
 		de: "Moderation",
@@ -2458,7 +2458,7 @@ export const pageLabels = {
 	},
 	"comments.moderationQueue": {
 		en: "Moderation Queue",
-		ar: "Moderation Queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة انتظار الإشراف",
 		es: "Cola de moderación",
 		fr: "File de modération",
 		de: "Moderations-Warteschlange",
@@ -2470,7 +2470,7 @@ export const pageLabels = {
 	},
 	"comments.moderationQueueDesc": {
 		en: "Review public comments and approve or reject them without leaving the queue.",
-		ar: "Review public comments and approve or reject them without leaving the queue.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "راجع التعليقات العامة واعتمدها أو ارفضها دون مغادرة قائمة الانتظار.",
 		es: "Revisa comentarios públicos y apruébalos o recházalos sin salir de la cola.",
 		fr: "Examinez les commentaires publics et approuvez ou rejetez sans quitter la file.",
 		de: "Prüfen Sie öffentliche Kommentare und genehmigen oder lehnen Sie sie ohne Verlassen der Warteschlange ab.",
@@ -2482,7 +2482,7 @@ export const pageLabels = {
 	},
 	"comments.queueAria": {
 		en: "Comments queue",
-		ar: "Comments queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة انتظار التعليقات",
 		es: "Cola de comentarios",
 		fr: "File des commentaires",
 		de: "Kommentar-Warteschlange",
@@ -2494,7 +2494,7 @@ export const pageLabels = {
 	},
 	"comments.author": {
 		en: "Author",
-		ar: "Author", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المؤلف",
 		es: "Autor",
 		fr: "Auteur",
 		de: "Autor",
@@ -2506,7 +2506,7 @@ export const pageLabels = {
 	},
 	"comments.route": {
 		en: "Route",
-		ar: "Route", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسار",
 		es: "Ruta",
 		fr: "Route",
 		de: "Route",
@@ -2518,7 +2518,7 @@ export const pageLabels = {
 	},
 	"comments.policy": {
 		en: "Policy",
-		ar: "Policy", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "السياسة",
 		es: "Política",
 		fr: "Politique",
 		de: "Richtlinie",
@@ -2530,7 +2530,7 @@ export const pageLabels = {
 	},
 	"comments.action": {
 		en: "Action",
-		ar: "Action", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجراء",
 		es: "Acción",
 		fr: "Action",
 		de: "Aktion",
@@ -2542,7 +2542,7 @@ export const pageLabels = {
 	},
 	"comments.empty": {
 		en: "No comments to moderate. Comments will appear here when visitors leave them on your posts.",
-		ar: "No comments to moderate. Comments will appear here when visitors leave them on your posts.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد تعليقات للإشراف عليها. ستظهر هنا عندما يتركها الزوار على منشوراتك.",
 		es: "No hay comentarios para moderar. Los comentarios aparecerán aquí cuando los visitantes los dejen en tus entradas.",
 		fr: "Aucun commentaire à modérer. Les commentaires apparaîtront ici lorsque des visiteurs en laisseront sur vos articles.",
 		de: "Keine Kommentare zum Moderieren. Kommentare erscheinen hier, sobald Besucher sie hinterlassen.",
@@ -2554,7 +2554,7 @@ export const pageLabels = {
 	},
 	"comments.approve": {
 		en: "Approve",
-		ar: "Approve", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اعتماد",
 		es: "Aprobar",
 		fr: "Approuver",
 		de: "Genehmigen",
@@ -2566,7 +2566,7 @@ export const pageLabels = {
 	},
 	"comments.reject": {
 		en: "Reject",
-		ar: "Reject", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رفض",
 		es: "Rechazar",
 		fr: "Rejeter",
 		de: "Ablehnen",
@@ -2578,7 +2578,7 @@ export const pageLabels = {
 	},
 	"comments.rejectDialogTitle": {
 		en: "Reject comment?",
-		ar: "Reject comment?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رفض التعليق؟",
 		es: "¿Rechazar comentario?",
 		fr: "Rejeter le commentaire ?",
 		de: "Kommentar ablehnen?",
@@ -2590,7 +2590,7 @@ export const pageLabels = {
 	},
 	"comments.rejectDialogBody": {
 		en: "Are you sure you want to reject this comment? It will be removed from the queue.",
-		ar: "Are you sure you want to reject this comment? It will be removed from the queue.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد رفض هذا التعليق؟ سيُحذف من قائمة الانتظار.",
 		es: "¿Seguro que quieres rechazar este comentario? Se eliminará de la cola.",
 		fr: "Voulez-vous vraiment rejeter ce commentaire ? Il sera retiré de la file.",
 		de: "Möchten Sie diesen Kommentar wirklich ablehnen? Er wird aus der Warteschlange entfernt.",
@@ -2602,7 +2602,7 @@ export const pageLabels = {
 	},
 	"comments.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -2614,7 +2614,7 @@ export const pageLabels = {
 	},
 	"comments.statusPending": {
 		en: "pending",
-		ar: "pending", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "معلَّق",
 		es: "pendiente",
 		fr: "en attente",
 		de: "ausstehend",
@@ -2626,7 +2626,7 @@ export const pageLabels = {
 	},
 	"comments.statusApproved": {
 		en: "approved",
-		ar: "approved", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "معتمَد",
 		es: "aprobado",
 		fr: "approuvé",
 		de: "genehmigt",
@@ -2638,7 +2638,7 @@ export const pageLabels = {
 	},
 	"comments.statusRejected": {
 		en: "rejected",
-		ar: "rejected", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مرفوض",
 		es: "rechazado",
 		fr: "rejeté",
 		de: "abgelehnt",
@@ -2650,7 +2650,7 @@ export const pageLabels = {
 	},
 	"comments.policyOpenModerated": {
 		en: "open-moderated",
-		ar: "open-moderated", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مفتوح-تحت الإشراف",
 		es: "abierto-moderado",
 		fr: "ouvert-modéré",
 		de: "offen-moderiert",
@@ -2664,7 +2664,7 @@ export const pageLabels = {
 	// ── Redirects ───────────────────────────────────────────────────────────
 	"redirects.description": {
 		en: "Reviewed redirect rules are manageable as product data.",
-		ar: "Reviewed redirect rules are manageable as product data.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تُدار قواعد إعادة التوجيه التي تمت مراجعتها كبيانات منتج.",
 		es: "Las reglas de redirección revisadas son gestionables como datos de producto.",
 		fr: "Les règles de redirection révisées sont gérables comme des données produit.",
 		de: "Geprüfte Weiterleitungsregeln sind als Produktdaten verwaltbar.",
@@ -2676,7 +2676,7 @@ export const pageLabels = {
 	},
 	"redirects.partialResults": {
 		en: "Some redirect data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some redirect data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات إعادة التوجيه غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de redirección no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de redirection sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Weiterleitungsdaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -2688,7 +2688,7 @@ export const pageLabels = {
 	},
 	"redirects.addRule": {
 		en: "Add rule",
-		ar: "Add rule", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إضافة قاعدة",
 		es: "Añadir regla",
 		fr: "Ajouter une règle",
 		de: "Regel hinzufügen",
@@ -2700,7 +2700,7 @@ export const pageLabels = {
 	},
 	"redirects.create": {
 		en: "Create Redirect",
-		ar: "Create Redirect", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إنشاء إعادة توجيه",
 		es: "Crear redirección",
 		fr: "Créer une redirection",
 		de: "Weiterleitung erstellen",
@@ -2712,7 +2712,7 @@ export const pageLabels = {
 	},
 	"redirects.newRule": {
 		en: "New Redirect Rule",
-		ar: "New Redirect Rule", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قاعدة إعادة توجيه جديدة",
 		es: "Nueva regla de redirección",
 		fr: "Nouvelle règle de redirection",
 		de: "Neue Weiterleitungsregel",
@@ -2724,7 +2724,7 @@ export const pageLabels = {
 	},
 	"redirects.newRuleDesc": {
 		en: "Add reviewed redirects as product data so old URLs stay intentional.",
-		ar: "Add reviewed redirects as product data so old URLs stay intentional.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أضِف عمليات إعادة التوجيه التي تمت مراجعتها كبيانات منتج لتبقى الروابط القديمة مقصودة.",
 		es: "Añade redirecciones revisadas como datos de producto para mantener intencionales las URL antiguas.",
 		fr: "Ajoutez des redirections révisées en tant que données produit pour que les anciennes URL restent intentionnelles.",
 		de: "Fügen Sie geprüfte Weiterleitungen als Produktdaten hinzu, damit alte URLs absichtlich bleiben.",
@@ -2736,7 +2736,7 @@ export const pageLabels = {
 	},
 	"redirects.legacyPath": {
 		en: "Legacy path",
-		ar: "Legacy path", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسار قديم",
 		es: "Ruta heredada",
 		fr: "Chemin hérité",
 		de: "Alter Pfad",
@@ -2748,7 +2748,7 @@ export const pageLabels = {
 	},
 	"redirects.targetPath": {
 		en: "Target path",
-		ar: "Target path", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسار الهدف",
 		es: "Ruta destino",
 		fr: "Chemin cible",
 		de: "Zielpfad",
@@ -2760,7 +2760,7 @@ export const pageLabels = {
 	},
 	"redirects.statusCode": {
 		en: "Status code",
-		ar: "Status code", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رمز الحالة",
 		es: "Código de estado",
 		fr: "Code de statut",
 		de: "Statuscode",
@@ -2772,7 +2772,7 @@ export const pageLabels = {
 	},
 	"redirects.saveRule": {
 		en: "Save rule",
-		ar: "Save rule", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ القاعدة",
 		es: "Guardar regla",
 		fr: "Enregistrer la règle",
 		de: "Regel speichern",
@@ -2784,7 +2784,7 @@ export const pageLabels = {
 	},
 	"redirects.inventory": {
 		en: "Redirect Inventory",
-		ar: "Redirect Inventory", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جرد إعادة التوجيه",
 		es: "Inventario de redirecciones",
 		fr: "Inventaire des redirections",
 		de: "Weiterleitungs-Inventar",
@@ -2796,7 +2796,7 @@ export const pageLabels = {
 	},
 	"redirects.reviewedRules": {
 		en: "Reviewed Redirect Rules",
-		ar: "Reviewed Redirect Rules", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قواعد إعادة التوجيه التي تمت مراجعتها",
 		es: "Reglas de redirección revisadas",
 		fr: "Règles de redirection révisées",
 		de: "Geprüfte Weiterleitungsregeln",
@@ -2808,7 +2808,7 @@ export const pageLabels = {
 	},
 	"redirects.reviewedRulesDesc": {
 		en: "Delete only when a route is intentionally retired or replaced elsewhere.",
-		ar: "Delete only when a route is intentionally retired or replaced elsewhere.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "احذف فقط حين يتقاعد المسار قصدًا أو يُستبدل في مكان آخر.",
 		es: "Elimina solo cuando una ruta se retira intencionalmente o se reemplaza en otro lugar.",
 		fr: "Supprimez uniquement lorsqu'une route est intentionnellement retirée ou remplacée ailleurs.",
 		de: "Nur löschen, wenn eine Route absichtlich entfernt oder anderswo ersetzt wird.",
@@ -2820,7 +2820,7 @@ export const pageLabels = {
 	},
 	"redirects.legacy": {
 		en: "Legacy",
-		ar: "Legacy", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قديم",
 		es: "Heredado",
 		fr: "Hérité",
 		de: "Alt",
@@ -2832,7 +2832,7 @@ export const pageLabels = {
 	},
 	"redirects.target": {
 		en: "Target",
-		ar: "Target", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الهدف",
 		es: "Destino",
 		fr: "Cible",
 		de: "Ziel",
@@ -2844,7 +2844,7 @@ export const pageLabels = {
 	},
 	"redirects.delete": {
 		en: "Delete",
-		ar: "Delete", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف",
 		es: "Eliminar",
 		fr: "Supprimer",
 		de: "Löschen",
@@ -2856,7 +2856,7 @@ export const pageLabels = {
 	},
 	"redirects.copy": {
 		en: "Copy",
-		ar: "Copy", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نسخ",
 		es: "Copiar",
 		fr: "Copier",
 		de: "Kopieren",
@@ -2868,7 +2868,7 @@ export const pageLabels = {
 	},
 	"redirects.empty": {
 		en: "No redirects yet. Add one above.",
-		ar: "No redirects yet. Add one above.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد عمليات إعادة توجيه بعد. أضِف واحدة أعلاه.",
 		es: "Aún no hay redirecciones. Añade una arriba.",
 		fr: "Aucune redirection pour le moment. Ajoutez-en une ci-dessus.",
 		de: "Noch keine Weiterleitungen. Fügen Sie oben eine hinzu.",
@@ -2880,7 +2880,7 @@ export const pageLabels = {
 	},
 	"redirects.deleteDialogTitle": {
 		en: "Delete redirect rule?",
-		ar: "Delete redirect rule?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف قاعدة إعادة التوجيه؟",
 		es: "¿Eliminar regla de redirección?",
 		fr: "Supprimer la règle de redirection ?",
 		de: "Weiterleitungsregel löschen?",
@@ -2892,7 +2892,7 @@ export const pageLabels = {
 	},
 	"redirects.deleteDialogBody": {
 		en: "Are you sure you want to delete this redirect rule?",
-		ar: "Are you sure you want to delete this redirect rule?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد حذف قاعدة إعادة التوجيه هذه؟",
 		es: "¿Seguro que quieres eliminar esta regla de redirección?",
 		fr: "Voulez-vous vraiment supprimer cette règle de redirection ?",
 		de: "Möchten Sie diese Weiterleitungsregel wirklich löschen?",
@@ -2904,7 +2904,7 @@ export const pageLabels = {
 	},
 	"redirects.deleteWarning": {
 		en: "This action cannot be undone.",
-		ar: "This action cannot be undone.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يمكن التراجع عن هذا الإجراء.",
 		es: "Esta acción no se puede deshacer.",
 		fr: "Cette action est irréversible.",
 		de: "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -2916,7 +2916,7 @@ export const pageLabels = {
 	},
 	"redirects.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -2928,7 +2928,7 @@ export const pageLabels = {
 	},
 	"redirects.deleteRule": {
 		en: "Delete rule",
-		ar: "Delete rule", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف القاعدة",
 		es: "Eliminar regla",
 		fr: "Supprimer la règle",
 		de: "Regel löschen",
@@ -2940,7 +2940,7 @@ export const pageLabels = {
 	},
 	"redirects.savedSuccess": {
 		en: "The reviewed redirect rule was added successfully.",
-		ar: "The reviewed redirect rule was added successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تمت إضافة قاعدة إعادة التوجيه التي تمت مراجعتها بنجاح.",
 		es: "La regla de redirección revisada se añadió correctamente.",
 		fr: "La règle de redirection révisée a été ajoutée avec succès.",
 		de: "Die geprüfte Weiterleitungsregel wurde erfolgreich hinzugefügt.",
@@ -2952,7 +2952,7 @@ export const pageLabels = {
 	},
 	"redirects.deletedSuccess": {
 		en: "The redirect rule was deleted successfully.",
-		ar: "The redirect rule was deleted successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حذف قاعدة إعادة التوجيه بنجاح.",
 		es: "La regla de redirección se eliminó correctamente.",
 		fr: "La règle de redirection a été supprimée avec succès.",
 		de: "Die Weiterleitungsregel wurde erfolgreich gelöscht.",
@@ -2964,7 +2964,7 @@ export const pageLabels = {
 	},
 	"redirects.tableAria": {
 		en: "Redirect rules",
-		ar: "Redirect rules", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قواعد إعادة التوجيه",
 		es: "Reglas de redirección",
 		fr: "Règles de redirection",
 		de: "Weiterleitungsregeln",
@@ -2978,7 +2978,7 @@ export const pageLabels = {
 	// ── Audit trail (shared component) ──────────────────────────────────────
 	"audit.recentTrail": {
 		en: "Recent Audit Trail",
-		ar: "Recent Audit Trail", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أثر التدقيق الحديث",
 		es: "Registro de auditoría reciente",
 		fr: "Journal d'audit récent",
 		de: "Aktuelles Audit-Protokoll",
@@ -2990,7 +2990,7 @@ export const pageLabels = {
 	},
 	"audit.empty": {
 		en: "No audit events have been recorded in this session yet.",
-		ar: "No audit events have been recorded in this session yet.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لم تُسجَّل أي أحداث تدقيق في هذه الجلسة بعد.",
 		es: "Aún no se han registrado eventos de auditoría en esta sesión.",
 		fr: "Aucun événement d'audit n'a été enregistré dans cette session.",
 		de: "In dieser Sitzung wurden noch keine Audit-Ereignisse erfasst.",
@@ -3002,7 +3002,7 @@ export const pageLabels = {
 	},
 	"audit.mediaAudit": {
 		en: "Media Audit",
-		ar: "Media Audit", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تدقيق الوسائط",
 		es: "Auditoría de medios",
 		fr: "Audit des médias",
 		de: "Medien-Audit",
@@ -3016,7 +3016,7 @@ export const pageLabels = {
 	// ── Authors ─────────────────────────────────────────────────────────────
 	"authors.title": {
 		en: "Authors",
-		ar: "Authors", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المؤلفون",
 		es: "Autores",
 		fr: "Auteurs",
 		de: "Autoren",
@@ -3028,7 +3028,7 @@ export const pageLabels = {
 	},
 	"authors.description": {
 		en: "Manage reusable author records for editorial attribution.",
-		ar: "Manage reusable author records for editorial attribution.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر سجلات المؤلفين القابلة لإعادة الاستخدام للنسب التحريري.",
 		es: "Gestiona registros de autor reutilizables para atribución editorial.",
 		fr: "Gérez les fiches d'auteur réutilisables pour l'attribution éditoriale.",
 		de: "Verwalten Sie wiederverwendbare Autorendatensätze für die redaktionelle Zuordnung.",
@@ -3040,7 +3040,7 @@ export const pageLabels = {
 	},
 	"authors.partialResults": {
 		en: "Some author data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some author data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات المؤلفين غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de autor no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données d'auteur sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Autorendaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -3052,7 +3052,7 @@ export const pageLabels = {
 	},
 	"authors.savedSuccess": {
 		en: "The author record was saved successfully.",
-		ar: "The author record was saved successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حفظ سجل المؤلف بنجاح.",
 		es: "El registro de autor se guardó correctamente.",
 		fr: "La fiche d'auteur a été enregistrée avec succès.",
 		de: "Der Autorendatensatz wurde erfolgreich gespeichert.",
@@ -3064,7 +3064,7 @@ export const pageLabels = {
 	},
 	"authors.deletedSuccess": {
 		en: "The author record was deleted successfully.",
-		ar: "The author record was deleted successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حذف سجل المؤلف بنجاح.",
 		es: "El registro de autor se eliminó correctamente.",
 		fr: "La fiche d'auteur a été supprimée avec succès.",
 		de: "Der Autorendatensatz wurde erfolgreich gelöscht.",
@@ -3076,7 +3076,7 @@ export const pageLabels = {
 	},
 	"authors.deletedToast": {
 		en: "Author deleted.",
-		ar: "Author deleted.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حذف المؤلف.",
 		es: "Autor eliminado.",
 		fr: "Auteur supprimé.",
 		de: "Autor gelöscht.",
@@ -3088,7 +3088,7 @@ export const pageLabels = {
 	},
 	"authors.undo": {
 		en: "Undo",
-		ar: "Undo", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تراجع",
 		es: "Deshacer",
 		fr: "Annuler",
 		de: "Rückgängig",
@@ -3100,7 +3100,7 @@ export const pageLabels = {
 	},
 	"authors.newAuthor": {
 		en: "New Author",
-		ar: "New Author", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مؤلف جديد",
 		es: "Nuevo autor",
 		fr: "Nouvel auteur",
 		de: "Neuer Autor",
@@ -3112,7 +3112,7 @@ export const pageLabels = {
 	},
 	"authors.newAuthorDesc": {
 		en: "Create reusable attribution records for posts and legacy content.",
-		ar: "Create reusable attribution records for posts and legacy content.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أنشئ سجلات نسب قابلة للاستخدام لمنشوراتك ومحتواك القديم.",
 		es: "Crea registros de atribución reutilizables para publicaciones y contenido heredado.",
 		fr: "Créez des fiches d'attribution réutilisables pour les articles et le contenu hérité.",
 		de: "Erstellen Sie wiederverwendbare Zuordnungsdatensätze für Beiträge und Bestandsinhalte.",
@@ -3124,7 +3124,7 @@ export const pageLabels = {
 	},
 	"authors.authorName": {
 		en: "Author name",
-		ar: "Author name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اسم المؤلف",
 		es: "Nombre del autor",
 		fr: "Nom de l'auteur",
 		de: "Autorenname",
@@ -3136,7 +3136,7 @@ export const pageLabels = {
 	},
 	"authors.slug": {
 		en: "Slug",
-		ar: "Slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف",
 		es: "Slug",
 		fr: "Slug",
 		de: "Slug",
@@ -3148,7 +3148,7 @@ export const pageLabels = {
 	},
 	"authors.authorSlug": {
 		en: "Author slug",
-		ar: "Author slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف للمؤلف",
 		es: "Slug del autor",
 		fr: "Slug de l'auteur",
 		de: "Autoren-Slug",
@@ -3160,7 +3160,7 @@ export const pageLabels = {
 	},
 	"authors.bio": {
 		en: "Bio",
-		ar: "Bio", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نبذة",
 		es: "Biografía",
 		fr: "Bio",
 		de: "Bio",
@@ -3172,7 +3172,7 @@ export const pageLabels = {
 	},
 	"authors.authorBio": {
 		en: "Author bio",
-		ar: "Author bio", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نبذة عن المؤلف",
 		es: "Biografía del autor",
 		fr: "Bio de l'auteur",
 		de: "Autorenbiografie",
@@ -3184,7 +3184,7 @@ export const pageLabels = {
 	},
 	"authors.bioPlaceholder": {
 		en: "Short author biography",
-		ar: "Short author biography", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نبذة قصيرة عن المؤلف",
 		es: "Biografía breve del autor",
 		fr: "Brève biographie de l'auteur",
 		de: "Kurze Autorenbiografie",
@@ -3196,7 +3196,7 @@ export const pageLabels = {
 	},
 	"authors.saveAuthor": {
 		en: "Save author",
-		ar: "Save author", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ المؤلف",
 		es: "Guardar autor",
 		fr: "Enregistrer l'auteur",
 		de: "Autor speichern",
@@ -3208,7 +3208,7 @@ export const pageLabels = {
 	},
 	"authors.listDesc": {
 		en: "Edit author details inline and remove records that are no longer needed.",
-		ar: "Edit author details inline and remove records that are no longer needed.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حرِّر تفاصيل المؤلف داخل القائمة واحذف السجلات غير اللازمة.",
 		es: "Edita los detalles del autor en línea y elimina los registros que ya no se necesitan.",
 		fr: "Modifiez les détails de l'auteur en ligne et supprimez les fiches qui ne sont plus nécessaires.",
 		de: "Bearbeiten Sie Autorendetails inline und entfernen Sie nicht mehr benötigte Datensätze.",
@@ -3220,7 +3220,7 @@ export const pageLabels = {
 	},
 	"authors.tableAria": {
 		en: "Authors",
-		ar: "Authors", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المؤلفون",
 		es: "Autores",
 		fr: "Auteurs",
 		de: "Autoren",
@@ -3232,7 +3232,7 @@ export const pageLabels = {
 	},
 	"authors.thName": {
 		en: "Name",
-		ar: "Name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الاسم",
 		es: "Nombre",
 		fr: "Nom",
 		de: "Name",
@@ -3244,7 +3244,7 @@ export const pageLabels = {
 	},
 	"authors.thSlug": {
 		en: "Slug",
-		ar: "Slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف",
 		es: "Slug",
 		fr: "Slug",
 		de: "Slug",
@@ -3256,7 +3256,7 @@ export const pageLabels = {
 	},
 	"authors.thBio": {
 		en: "Bio",
-		ar: "Bio", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نبذة",
 		es: "Biografía",
 		fr: "Bio",
 		de: "Bio",
@@ -3268,7 +3268,7 @@ export const pageLabels = {
 	},
 	"authors.edit": {
 		en: "Edit",
-		ar: "Edit", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل",
 		es: "Editar",
 		fr: "Modifier",
 		de: "Bearbeiten",
@@ -3280,7 +3280,7 @@ export const pageLabels = {
 	},
 	"authors.update": {
 		en: "Update",
-		ar: "Update", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحديث",
 		es: "Actualizar",
 		fr: "Mettre à jour",
 		de: "Aktualisieren",
@@ -3292,7 +3292,7 @@ export const pageLabels = {
 	},
 	"authors.delete": {
 		en: "Delete",
-		ar: "Delete", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف",
 		es: "Eliminar",
 		fr: "Supprimer",
 		de: "Löschen",
@@ -3304,7 +3304,7 @@ export const pageLabels = {
 	},
 	"authors.ariaName": {
 		en: "Name",
-		ar: "Name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الاسم",
 		es: "Nombre",
 		fr: "Nom",
 		de: "Name",
@@ -3316,7 +3316,7 @@ export const pageLabels = {
 	},
 	"authors.ariaSlug": {
 		en: "Slug",
-		ar: "Slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف",
 		es: "Slug",
 		fr: "Slug",
 		de: "Slug",
@@ -3328,7 +3328,7 @@ export const pageLabels = {
 	},
 	"authors.ariaBio": {
 		en: "Bio",
-		ar: "Bio", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نبذة",
 		es: "Biografía",
 		fr: "Bio",
 		de: "Bio",
@@ -3340,7 +3340,7 @@ export const pageLabels = {
 	},
 	"authors.deleteDialogTitle": {
 		en: "Delete author?",
-		ar: "Delete author?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف المؤلف؟",
 		es: "¿Eliminar autor?",
 		fr: "Supprimer l'auteur ?",
 		de: "Autor löschen?",
@@ -3352,7 +3352,7 @@ export const pageLabels = {
 	},
 	"authors.deleteConfirmPrefix": {
 		en: "Are you sure you want to delete ",
-		ar: "Are you sure you want to delete ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد حذف ",
 		es: "¿Seguro que quieres eliminar ",
 		fr: "Voulez-vous vraiment supprimer ",
 		de: "Möchten Sie wirklich ",
@@ -3364,7 +3364,7 @@ export const pageLabels = {
 	},
 	"authors.deleteConfirmSuffix": {
 		en: "?",
-		ar: "?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "؟",
 		es: "?",
 		fr: " ?",
 		de: " löschen?",
@@ -3376,7 +3376,7 @@ export const pageLabels = {
 	},
 	"authors.deleteWarning": {
 		en: "This action cannot be undone.",
-		ar: "This action cannot be undone.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يمكن التراجع عن هذا الإجراء.",
 		es: "Esta acción no se puede deshacer.",
 		fr: "Cette action est irréversible.",
 		de: "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -3388,7 +3388,7 @@ export const pageLabels = {
 	},
 	"authors.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -3400,7 +3400,7 @@ export const pageLabels = {
 	},
 	"authors.deleteAuthor": {
 		en: "Delete Author",
-		ar: "Delete Author", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف المؤلف",
 		es: "Eliminar autor",
 		fr: "Supprimer l'auteur",
 		de: "Autor löschen",
@@ -3412,7 +3412,7 @@ export const pageLabels = {
 	},
 	"authors.forbiddenTitle": {
 		en: "Forbidden",
-		ar: "Forbidden", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ممنوع",
 		es: "Prohibido",
 		fr: "Interdit",
 		de: "Verboten",
@@ -3426,7 +3426,7 @@ export const pageLabels = {
 	// ── Taxonomies ──────────────────────────────────────────────────────────
 	"taxonomies.title": {
 		en: "Taxonomies",
-		ar: "Taxonomies", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التصنيفات",
 		es: "Taxonomías",
 		fr: "Taxonomies",
 		de: "Taxonomien",
@@ -3438,7 +3438,7 @@ export const pageLabels = {
 	},
 	"taxonomies.description": {
 		en: "Manage reusable categories and tags for future editorial workflows.",
-		ar: "Manage reusable categories and tags for future editorial workflows.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر التصنيفات والوسوم القابلة لإعادة الاستخدام لسير العمل التحريري المستقبلي.",
 		es: "Gestiona categorías y etiquetas reutilizables para futuros flujos editoriales.",
 		fr: "Gérez les catégories et étiquettes réutilisables pour les futurs flux éditoriaux.",
 		de: "Verwalten Sie wiederverwendbare Kategorien und Tags für künftige redaktionelle Abläufe.",
@@ -3450,7 +3450,7 @@ export const pageLabels = {
 	},
 	"taxonomies.partialResults": {
 		en: "Some taxonomy data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some taxonomy data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات التصنيفات غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de taxonomía no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de taxonomie sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Taxonomiedaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -3462,7 +3462,7 @@ export const pageLabels = {
 	},
 	"taxonomies.savedSuccess": {
 		en: "The taxonomy term was saved successfully.",
-		ar: "The taxonomy term was saved successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حفظ مصطلح التصنيف بنجاح.",
 		es: "El término de taxonomía se guardó correctamente.",
 		fr: "Le terme de taxonomie a été enregistré avec succès.",
 		de: "Der Taxonomiebegriff wurde erfolgreich gespeichert.",
@@ -3474,7 +3474,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deletedSuccess": {
 		en: "The taxonomy term was deleted successfully.",
-		ar: "The taxonomy term was deleted successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حذف مصطلح التصنيف بنجاح.",
 		es: "El término de taxonomía se eliminó correctamente.",
 		fr: "Le terme de taxonomie a été supprimé avec succès.",
 		de: "Der Taxonomiebegriff wurde erfolgreich gelöscht.",
@@ -3486,7 +3486,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deletedToast": {
 		en: "Taxonomy term deleted.",
-		ar: "Taxonomy term deleted.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حذف مصطلح التصنيف.",
 		es: "Término de taxonomía eliminado.",
 		fr: "Terme de taxonomie supprimé.",
 		de: "Taxonomiebegriff gelöscht.",
@@ -3498,7 +3498,7 @@ export const pageLabels = {
 	},
 	"taxonomies.undo": {
 		en: "Undo",
-		ar: "Undo", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تراجع",
 		es: "Deshacer",
 		fr: "Annuler",
 		de: "Rückgängig",
@@ -3510,7 +3510,7 @@ export const pageLabels = {
 	},
 	"taxonomies.categories": {
 		en: "Categories",
-		ar: "Categories", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التصنيفات",
 		es: "Categorías",
 		fr: "Catégories",
 		de: "Kategorien",
@@ -3522,7 +3522,7 @@ export const pageLabels = {
 	},
 	"taxonomies.categoriesDesc": {
 		en: "Group posts into durable archive families and editorial buckets.",
-		ar: "Group posts into durable archive families and editorial buckets.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اجمع المنشورات في عائلات أرشيف ثابتة وحاويات تحريرية.",
 		es: "Agrupa publicaciones en familias de archivo duraderas y cubos editoriales.",
 		fr: "Regroupez les articles en familles d'archives durables et en groupes éditoriaux.",
 		de: "Gruppieren Sie Beiträge in dauerhafte Archivfamilien und redaktionelle Sammelgruppen.",
@@ -3534,7 +3534,7 @@ export const pageLabels = {
 	},
 	"taxonomies.categoryName": {
 		en: "Category name",
-		ar: "Category name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اسم التصنيف",
 		es: "Nombre de categoría",
 		fr: "Nom de catégorie",
 		de: "Kategoriename",
@@ -3546,7 +3546,7 @@ export const pageLabels = {
 	},
 	"taxonomies.categorySlug": {
 		en: "Category slug",
-		ar: "Category slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف للتصنيف",
 		es: "Slug de categoría",
 		fr: "Slug de catégorie",
 		de: "Kategorie-Slug",
@@ -3558,7 +3558,7 @@ export const pageLabels = {
 	},
 	"taxonomies.categoryDescription": {
 		en: "Category description",
-		ar: "Category description", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وصف التصنيف",
 		es: "Descripción de categoría",
 		fr: "Description de catégorie",
 		de: "Kategoriebeschreibung",
@@ -3570,7 +3570,7 @@ export const pageLabels = {
 	},
 	"taxonomies.saveCategory": {
 		en: "Save category",
-		ar: "Save category", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ التصنيف",
 		es: "Guardar categoría",
 		fr: "Enregistrer la catégorie",
 		de: "Kategorie speichern",
@@ -3582,7 +3582,7 @@ export const pageLabels = {
 	},
 	"taxonomies.tags": {
 		en: "Tags",
-		ar: "Tags", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الوسوم",
 		es: "Etiquetas",
 		fr: "Étiquettes",
 		de: "Tags",
@@ -3594,7 +3594,7 @@ export const pageLabels = {
 	},
 	"taxonomies.tagsDesc": {
 		en: "Capture lighter-weight topical labels without creating a whole category family.",
-		ar: "Capture lighter-weight topical labels without creating a whole category family.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سجِّل وسومًا موضوعية أخف وزنًا دون إنشاء عائلة تصنيف كاملة.",
 		es: "Captura etiquetas temáticas más ligeras sin crear toda una familia de categorías.",
 		fr: "Capturez des étiquettes thématiques plus légères sans créer toute une famille de catégories.",
 		de: "Erfassen Sie leichtere Themenkennzeichnungen, ohne eine ganze Kategorienfamilie zu erstellen.",
@@ -3606,7 +3606,7 @@ export const pageLabels = {
 	},
 	"taxonomies.tagName": {
 		en: "Tag name",
-		ar: "Tag name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اسم الوسم",
 		es: "Nombre de etiqueta",
 		fr: "Nom d'étiquette",
 		de: "Tag-Name",
@@ -3618,7 +3618,7 @@ export const pageLabels = {
 	},
 	"taxonomies.tagSlug": {
 		en: "Tag slug",
-		ar: "Tag slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف للوسم",
 		es: "Slug de etiqueta",
 		fr: "Slug d'étiquette",
 		de: "Tag-Slug",
@@ -3630,7 +3630,7 @@ export const pageLabels = {
 	},
 	"taxonomies.tagDescription": {
 		en: "Tag description",
-		ar: "Tag description", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وصف الوسم",
 		es: "Descripción de etiqueta",
 		fr: "Description d'étiquette",
 		de: "Tag-Beschreibung",
@@ -3642,7 +3642,7 @@ export const pageLabels = {
 	},
 	"taxonomies.saveTag": {
 		en: "Save tag",
-		ar: "Save tag", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ الوسم",
 		es: "Guardar etiqueta",
 		fr: "Enregistrer l'étiquette",
 		de: "Tag speichern",
@@ -3654,7 +3654,7 @@ export const pageLabels = {
 	},
 	"taxonomies.slug": {
 		en: "Slug",
-		ar: "Slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف",
 		es: "Slug",
 		fr: "Slug",
 		de: "Slug",
@@ -3666,7 +3666,7 @@ export const pageLabels = {
 	},
 	"taxonomies.descriptionField": {
 		en: "Description",
-		ar: "Description", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الوصف",
 		es: "Descripción",
 		fr: "Description",
 		de: "Beschreibung",
@@ -3678,7 +3678,7 @@ export const pageLabels = {
 	},
 	"taxonomies.thName": {
 		en: "Name",
-		ar: "Name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الاسم",
 		es: "Nombre",
 		fr: "Nom",
 		de: "Name",
@@ -3690,7 +3690,7 @@ export const pageLabels = {
 	},
 	"taxonomies.thSlug": {
 		en: "Slug",
-		ar: "Slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف",
 		es: "Slug",
 		fr: "Slug",
 		de: "Slug",
@@ -3702,7 +3702,7 @@ export const pageLabels = {
 	},
 	"taxonomies.edit": {
 		en: "Edit",
-		ar: "Edit", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل",
 		es: "Editar",
 		fr: "Modifier",
 		de: "Bearbeiten",
@@ -3714,7 +3714,7 @@ export const pageLabels = {
 	},
 	"taxonomies.update": {
 		en: "Update",
-		ar: "Update", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحديث",
 		es: "Actualizar",
 		fr: "Mettre à jour",
 		de: "Aktualisieren",
@@ -3726,7 +3726,7 @@ export const pageLabels = {
 	},
 	"taxonomies.delete": {
 		en: "Delete",
-		ar: "Delete", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف",
 		es: "Eliminar",
 		fr: "Supprimer",
 		de: "Löschen",
@@ -3738,7 +3738,7 @@ export const pageLabels = {
 	},
 	"taxonomies.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -3750,7 +3750,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deleteWarning": {
 		en: "This action cannot be undone.",
-		ar: "This action cannot be undone.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يمكن التراجع عن هذا الإجراء.",
 		es: "Esta acción no se puede deshacer.",
 		fr: "Cette action est irréversible.",
 		de: "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -3762,7 +3762,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deleteConfirmPrefix": {
 		en: "Are you sure you want to delete ",
-		ar: "Are you sure you want to delete ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد حذف ",
 		es: "¿Seguro que quieres eliminar ",
 		fr: "Voulez-vous vraiment supprimer ",
 		de: "Möchten Sie wirklich ",
@@ -3774,7 +3774,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deleteConfirmSuffix": {
 		en: "?",
-		ar: "?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "؟",
 		es: "?",
 		fr: " ?",
 		de: " löschen?",
@@ -3786,7 +3786,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deleteCategoryDialogTitle": {
 		en: "Delete category?",
-		ar: "Delete category?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف التصنيف؟",
 		es: "¿Eliminar categoría?",
 		fr: "Supprimer la catégorie ?",
 		de: "Kategorie löschen?",
@@ -3798,7 +3798,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deleteCategory": {
 		en: "Delete Category",
-		ar: "Delete Category", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف التصنيف",
 		es: "Eliminar categoría",
 		fr: "Supprimer la catégorie",
 		de: "Kategorie löschen",
@@ -3810,7 +3810,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deleteTagDialogTitle": {
 		en: "Delete tag?",
-		ar: "Delete tag?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف الوسم؟",
 		es: "¿Eliminar etiqueta?",
 		fr: "Supprimer l'étiquette ?",
 		de: "Tag löschen?",
@@ -3822,7 +3822,7 @@ export const pageLabels = {
 	},
 	"taxonomies.deleteTag": {
 		en: "Delete Tag",
-		ar: "Delete Tag", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف الوسم",
 		es: "Eliminar etiqueta",
 		fr: "Supprimer l'étiquette",
 		de: "Tag löschen",
@@ -3834,7 +3834,7 @@ export const pageLabels = {
 	},
 	"taxonomies.forbiddenTitle": {
 		en: "Forbidden",
-		ar: "Forbidden", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ممنوع",
 		es: "Prohibido",
 		fr: "Interdit",
 		de: "Verboten",
@@ -3848,7 +3848,7 @@ export const pageLabels = {
 	// ── Footer (shared) ─────────────────────────────────────────────────────
 	"layout.skipToContent": {
 		en: "Skip to admin content",
-		ar: "Skip to admin content", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تخطّي إلى محتوى الإدارة",
 		es: "Saltar al contenido de administración",
 		fr: "Passer au contenu d'administration",
 		de: "Zum Admin-Inhalt springen",
@@ -3860,7 +3860,7 @@ export const pageLabels = {
 	},
 	"layout.openNavigation": {
 		en: "Open navigation",
-		ar: "Open navigation", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح التنقل",
 		es: "Abrir navegación",
 		fr: "Ouvrir la navigation",
 		de: "Navigation öffnen",
@@ -3872,7 +3872,7 @@ export const pageLabels = {
 	},
 	"layout.closeNavigation": {
 		en: "Close navigation",
-		ar: "Close navigation", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إغلاق التنقل",
 		es: "Cerrar navegación",
 		fr: "Fermer la navigation",
 		de: "Navigation schließen",
@@ -3884,7 +3884,7 @@ export const pageLabels = {
 	},
 	"layout.toggleUtilityPanel": {
 		en: "Toggle utility panel",
-		ar: "Toggle utility panel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تبديل لوحة الأدوات",
 		es: "Alternar panel de utilidades",
 		fr: "Basculer le panneau utilitaire",
 		de: "Hilfsbereich umschalten",
@@ -3896,7 +3896,7 @@ export const pageLabels = {
 	},
 	"layout.keyboardShortcuts": {
 		en: "Keyboard shortcuts",
-		ar: "Keyboard shortcuts", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اختصارات لوحة المفاتيح",
 		es: "Atajos de teclado",
 		fr: "Raccourcis clavier",
 		de: "Tastaturkürzel",
@@ -3908,7 +3908,7 @@ export const pageLabels = {
 	},
 	"layout.scrollToBottom": {
 		en: "Scroll to bottom",
-		ar: "Scroll to bottom", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التمرير إلى الأسفل",
 		es: "Desplazarse al final",
 		fr: "Aller en bas",
 		de: "Nach unten scrollen",
@@ -3920,7 +3920,7 @@ export const pageLabels = {
 	},
 	"layout.scrollToTop": {
 		en: "Scroll to top",
-		ar: "Scroll to top", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التمرير إلى الأعلى",
 		es: "Desplazarse al inicio",
 		fr: "Aller en haut",
 		de: "Nach oben scrollen",
@@ -3932,7 +3932,7 @@ export const pageLabels = {
 	},
 	"layout.adminSections": {
 		en: "Admin sections",
-		ar: "Admin sections", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أقسام الإدارة",
 		es: "Secciones de administración",
 		fr: "Sections d'administration",
 		de: "Admin-Bereiche",
@@ -3944,7 +3944,7 @@ export const pageLabels = {
 	},
 	"layout.recent": {
 		en: "Recent",
-		ar: "Recent", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حديث",
 		es: "Reciente",
 		fr: "Récent",
 		de: "Zuletzt",
@@ -3956,7 +3956,7 @@ export const pageLabels = {
 	},
 	"layout.commandPalette": {
 		en: "Command palette",
-		ar: "Command palette", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لوحة الأوامر",
 		es: "Paleta de comandos",
 		fr: "Palette de commandes",
 		de: "Befehlspalette",
@@ -3968,7 +3968,7 @@ export const pageLabels = {
 	},
 	"layout.commandPaletteResults": {
 		en: "Command palette results",
-		ar: "Command palette results", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نتائج لوحة الأوامر",
 		es: "Resultados de la paleta de comandos",
 		fr: "Résultats de la palette de commandes",
 		de: "Ergebnisse der Befehlspalette",
@@ -3980,7 +3980,7 @@ export const pageLabels = {
 	},
 	"layout.searchAdminPages": {
 		en: "Search admin pages",
-		ar: "Search admin pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البحث في صفحات الإدارة",
 		es: "Buscar páginas de administración",
 		fr: "Rechercher dans les pages d'administration",
 		de: "Admin-Seiten suchen",
@@ -3992,7 +3992,7 @@ export const pageLabels = {
 	},
 	"layout.shortcutSaveDraft": {
 		en: "Save draft",
-		ar: "Save draft", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ المسودة",
 		es: "Guardar borrador",
 		fr: "Enregistrer le brouillon",
 		de: "Entwurf speichern",
@@ -4004,7 +4004,7 @@ export const pageLabels = {
 	},
 	"layout.shortcutPublish": {
 		en: "Publish / submit form",
-		ar: "Publish / submit form", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نشر / إرسال النموذج",
 		es: "Publicar / enviar formulario",
 		fr: "Publier / soumettre le formulaire",
 		de: "Veröffentlichen / Formular absenden",
@@ -4016,7 +4016,7 @@ export const pageLabels = {
 	},
 	"layout.shortcutEscape": {
 		en: "Close dialog or panel",
-		ar: "Close dialog or panel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إغلاق مربع الحوار أو اللوحة",
 		es: "Cerrar diálogo o panel",
 		fr: "Fermer la boîte de dialogue ou le panneau",
 		de: "Dialog oder Panel schließen",
@@ -4028,7 +4028,7 @@ export const pageLabels = {
 	},
 	"layout.shortcutTab": {
 		en: "Move to next field",
-		ar: "Move to next field", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الانتقال إلى الحقل التالي",
 		es: "Ir al siguiente campo",
 		fr: "Aller au champ suivant",
 		de: "Zum nächsten Feld",
@@ -4040,7 +4040,7 @@ export const pageLabels = {
 	},
 	"layout.shortcutShiftTab": {
 		en: "Move to previous field",
-		ar: "Move to previous field", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الانتقال إلى الحقل السابق",
 		es: "Ir al campo anterior",
 		fr: "Aller au champ précédent",
 		de: "Zum vorherigen Feld",
@@ -4052,7 +4052,7 @@ export const pageLabels = {
 	},
 	"layout.shortcutHelp": {
 		en: "Show this help panel",
-		ar: "Show this help panel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عرض لوحة المساعدة هذه",
 		es: "Mostrar este panel de ayuda",
 		fr: "Afficher ce panneau d'aide",
 		de: "Diese Hilfe anzeigen",
@@ -4064,7 +4064,7 @@ export const pageLabels = {
 	},
 	"layout.shortcutCmd": {
 		en: "Open command palette",
-		ar: "Open command palette", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح لوحة الأوامر",
 		es: "Abrir paleta de comandos",
 		fr: "Ouvrir la palette de commandes",
 		de: "Befehlspalette öffnen",
@@ -4076,7 +4076,7 @@ export const pageLabels = {
 	},
 	"layout.goTo": {
 		en: "Go to…",
-		ar: "Go to…", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الانتقال إلى…",
 		es: "Ir a…",
 		fr: "Aller à…",
 		de: "Wechseln zu…",
@@ -4089,7 +4089,7 @@ export const pageLabels = {
 	// ANCHOR-BATCH-B: settings + users
 	"settings.title": {
 		en: "Settings",
-		ar: "Settings", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإعدادات",
 		es: "Configuración",
 		fr: "Paramètres",
 		de: "Einstellungen",
@@ -4101,7 +4101,7 @@ export const pageLabels = {
 	},
 	"settings.description": {
 		en: "Configure site-wide settings, newsletter, and content import.",
-		ar: "Configure site-wide settings, newsletter, and content import.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اضبط إعدادات الموقع العامة والنشرة البريدية واستيراد المحتوى.",
 		es: "Configure los ajustes del sitio, el boletín y la importación de contenido.",
 		fr: "Configurez les paramètres du site, la newsletter et l'importation de contenu.",
 		de: "Konfigurieren Sie websiteweite Einstellungen, Newsletter und Inhaltsimport.",
@@ -4113,7 +4113,7 @@ export const pageLabels = {
 	},
 	"settings.partialLoadNotice": {
 		en: "Settings could not be fully loaded. This page is showing safe fallback values.",
-		ar: "Settings could not be fully loaded. This page is showing safe fallback values.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعذّر تحميل الإعدادات بالكامل. تعرض هذه الصفحة قيمًا احتياطية آمنة.",
 		es: "No se pudieron cargar todos los ajustes. Esta página muestra valores seguros de respaldo.",
 		fr: "Les paramètres n'ont pas pu être entièrement chargés. Cette page affiche des valeurs de repli sûres.",
 		de: "Die Einstellungen konnten nicht vollständig geladen werden. Diese Seite zeigt sichere Ersatzwerte.",
@@ -4125,7 +4125,7 @@ export const pageLabels = {
 	},
 	"settings.savedNotice": {
 		en: "Settings saved successfully.",
-		ar: "Settings saved successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حفظ الإعدادات بنجاح.",
 		es: "Configuración guardada con éxito.",
 		fr: "Paramètres enregistrés avec succès.",
 		de: "Einstellungen erfolgreich gespeichert.",
@@ -4137,7 +4137,7 @@ export const pageLabels = {
 	},
 	"settings.tabsLabel": {
 		en: "Settings sections",
-		ar: "Settings sections", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أقسام الإعدادات",
 		es: "Secciones de configuración",
 		fr: "Sections des paramètres",
 		de: "Einstellungsbereiche",
@@ -4149,7 +4149,7 @@ export const pageLabels = {
 	},
 	"settings.tabGeneral": {
 		en: "General",
-		ar: "General", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عام",
 		es: "General",
 		fr: "Général",
 		de: "Allgemein",
@@ -4161,7 +4161,7 @@ export const pageLabels = {
 	},
 	"settings.tabNewsletter": {
 		en: "Newsletter",
-		ar: "Newsletter", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النشرة البريدية",
 		es: "Boletín",
 		fr: "Newsletter",
 		de: "Newsletter",
@@ -4173,7 +4173,7 @@ export const pageLabels = {
 	},
 	"settings.tabImport": {
 		en: "Import",
-		ar: "Import", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استيراد",
 		es: "Importar",
 		fr: "Importer",
 		de: "Importieren",
@@ -4185,7 +4185,7 @@ export const pageLabels = {
 	},
 	"settings.donationDestination": {
 		en: "Donation destination",
-		ar: "Donation destination", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وجهة التبرع",
 		es: "Destino de donación",
 		fr: "Destination de don",
 		de: "Spendenziel",
@@ -4197,7 +4197,7 @@ export const pageLabels = {
 	},
 	"settings.donationDestinationDesc": {
 		en: "Primary site-wide donation URL configured here.",
-		ar: "Primary site-wide donation URL configured here.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط التبرع الرئيسي للموقع المُهيَّأ هنا.",
 		es: "URL principal de donación de todo el sitio configurada aquí.",
 		fr: "URL principale de don à l'échelle du site configurée ici.",
 		de: "Hier konfigurierte primäre, websiteweite Spenden-URL.",
@@ -4209,7 +4209,7 @@ export const pageLabels = {
 	},
 	"settings.newsletterState": {
 		en: "Newsletter state",
-		ar: "Newsletter state", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حالة النشرة البريدية",
 		es: "Estado del boletín",
 		fr: "État de la newsletter",
 		de: "Newsletter-Status",
@@ -4221,7 +4221,7 @@ export const pageLabels = {
 	},
 	"settings.newsletterStateDesc": {
 		en: "Controls newsletter collection across public signup surfaces.",
-		ar: "Controls newsletter collection across public signup surfaces.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتحكّم بجمع النشرة البريدية عبر أسطح الاشتراك العامة.",
 		es: "Controla la recolección del boletín en las superficies públicas de registro.",
 		fr: "Contrôle la collecte de la newsletter sur les surfaces d'inscription publiques.",
 		de: "Steuert die Newsletter-Erfassung auf öffentlichen Anmeldeflächen.",
@@ -4233,7 +4233,7 @@ export const pageLabels = {
 	},
 	"settings.on": {
 		en: "On",
-		ar: "On", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مُفعَّل",
 		es: "Activado",
 		fr: "Activé",
 		de: "Ein",
@@ -4245,7 +4245,7 @@ export const pageLabels = {
 	},
 	"settings.off": {
 		en: "Off",
-		ar: "Off", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "متوقّف",
 		es: "Desactivado",
 		fr: "Désactivé",
 		de: "Aus",
@@ -4257,7 +4257,7 @@ export const pageLabels = {
 	},
 	"settings.brandKicker": {
 		en: "Brand",
-		ar: "Brand", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الهوية",
 		es: "Marca",
 		fr: "Marque",
 		de: "Marke",
@@ -4269,7 +4269,7 @@ export const pageLabels = {
 	},
 	"settings.siteIdentity": {
 		en: "Site Identity",
-		ar: "Site Identity", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هوية الموقع",
 		es: "Identidad del sitio",
 		fr: "Identité du site",
 		de: "Website-Identität",
@@ -4281,7 +4281,7 @@ export const pageLabels = {
 	},
 	"settings.siteIdentityDesc": {
 		en: "Global naming and branding copy used across the public site.",
-		ar: "Global naming and branding copy used across the public site.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نصوص التسمية والهوية العامة المستخدمة في الموقع العام.",
 		es: "Nombres globales y textos de marca utilizados en todo el sitio público.",
 		fr: "Noms globaux et textes de marque utilisés sur tout le site public.",
 		de: "Globale Namen und Markentexte, die auf der gesamten öffentlichen Website verwendet werden.",
@@ -4293,7 +4293,7 @@ export const pageLabels = {
 	},
 	"settings.siteTitle": {
 		en: "Site title",
-		ar: "Site title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عنوان الموقع",
 		es: "Título del sitio",
 		fr: "Titre du site",
 		de: "Website-Titel",
@@ -4305,7 +4305,7 @@ export const pageLabels = {
 	},
 	"settings.siteTagline": {
 		en: "Site tagline",
-		ar: "Site tagline", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "شعار الموقع",
 		es: "Eslogan del sitio",
 		fr: "Slogan du site",
 		de: "Website-Slogan",
@@ -4317,7 +4317,7 @@ export const pageLabels = {
 	},
 	"settings.engagementKicker": {
 		en: "Engagement",
-		ar: "Engagement", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التفاعل",
 		es: "Interacción",
 		fr: "Engagement",
 		de: "Engagement",
@@ -4329,7 +4329,7 @@ export const pageLabels = {
 	},
 	"settings.newsletter": {
 		en: "Newsletter",
-		ar: "Newsletter", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النشرة البريدية",
 		es: "Boletín",
 		fr: "Newsletter",
 		de: "Newsletter",
@@ -4341,7 +4341,7 @@ export const pageLabels = {
 	},
 	"settings.newsletterDesc": {
 		en: "Enable or disable newsletter collection across public signup surfaces.",
-		ar: "Enable or disable newsletter collection across public signup surfaces.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فعِّل أو عطِّل جمع النشرة البريدية عبر أسطح الاشتراك العامة.",
 		es: "Active o desactive la recolección del boletín en las superficies públicas de registro.",
 		fr: "Activez ou désactivez la collecte de la newsletter sur les surfaces d'inscription publiques.",
 		de: "Aktivieren oder deaktivieren Sie die Newsletter-Erfassung auf öffentlichen Anmeldeflächen.",
@@ -4353,7 +4353,7 @@ export const pageLabels = {
 	},
 	"settings.enableNewsletter": {
 		en: "Enable newsletter signup",
-		ar: "Enable newsletter signup", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تفعيل الاشتراك في النشرة البريدية",
 		es: "Activar registro al boletín",
 		fr: "Activer l'inscription à la newsletter",
 		de: "Newsletter-Anmeldung aktivieren",
@@ -4365,7 +4365,7 @@ export const pageLabels = {
 	},
 	"settings.fundraisingKicker": {
 		en: "Fundraising",
-		ar: "Fundraising", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جمع التبرعات",
 		es: "Recaudación de fondos",
 		fr: "Collecte de fonds",
 		de: "Spendensammlung",
@@ -4377,7 +4377,7 @@ export const pageLabels = {
 	},
 	"settings.donationSettings": {
 		en: "Donation settings",
-		ar: "Donation settings", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إعدادات التبرع",
 		es: "Configuración de donaciones",
 		fr: "Paramètres de don",
 		de: "Spendeneinstellungen",
@@ -4389,7 +4389,7 @@ export const pageLabels = {
 	},
 	"settings.donationUrl": {
 		en: "Donation URL",
-		ar: "Donation URL", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط التبرع",
 		es: "URL de donación",
 		fr: "URL de don",
 		de: "Spenden-URL",
@@ -4401,7 +4401,7 @@ export const pageLabels = {
 	},
 	"settings.moderationKicker": {
 		en: "Moderation",
-		ar: "Moderation", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإشراف",
 		es: "Moderación",
 		fr: "Modération",
 		de: "Moderation",
@@ -4413,7 +4413,7 @@ export const pageLabels = {
 	},
 	"settings.commentSettings": {
 		en: "Comment settings",
-		ar: "Comment settings", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إعدادات التعليقات",
 		es: "Configuración de comentarios",
 		fr: "Paramètres des commentaires",
 		de: "Kommentareinstellungen",
@@ -4425,7 +4425,7 @@ export const pageLabels = {
 	},
 	"settings.defaultCommentPolicy": {
 		en: "Default comment policy",
-		ar: "Default comment policy", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سياسة التعليقات الافتراضية",
 		es: "Política de comentarios predeterminada",
 		fr: "Politique de commentaires par défaut",
 		de: "Standard-Kommentarrichtlinie",
@@ -4437,7 +4437,7 @@ export const pageLabels = {
 	},
 	"settings.commentDisabled": {
 		en: "Disabled",
-		ar: "Disabled", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مُعطَّل",
 		es: "Desactivado",
 		fr: "Désactivé",
 		de: "Deaktiviert",
@@ -4449,7 +4449,7 @@ export const pageLabels = {
 	},
 	"settings.commentLegacy": {
 		en: "Legacy (read-only)",
-		ar: "Legacy (read-only)", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قديم (للقراءة فقط)",
 		es: "Heredado (solo lectura)",
 		fr: "Hérité (lecture seule)",
 		de: "Legacy (schreibgeschützt)",
@@ -4461,7 +4461,7 @@ export const pageLabels = {
 	},
 	"settings.commentOpenModerated": {
 		en: "Open (moderated)",
-		ar: "Open (moderated)", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مفتوح (تحت الإشراف)",
 		es: "Abierto (moderado)",
 		fr: "Ouvert (modéré)",
 		de: "Offen (moderiert)",
@@ -4473,7 +4473,7 @@ export const pageLabels = {
 	},
 	"settings.saveButton": {
 		en: "Save settings",
-		ar: "Save settings", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ الإعدادات",
 		es: "Guardar configuración",
 		fr: "Enregistrer les paramètres",
 		de: "Einstellungen speichern",
@@ -4485,7 +4485,7 @@ export const pageLabels = {
 	},
 	"settings.subscriberRemoved": {
 		en: "Subscriber removed successfully.",
-		ar: "Subscriber removed successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تمت إزالة المشترك بنجاح.",
 		es: "Suscriptor eliminado con éxito.",
 		fr: "Abonné supprimé avec succès.",
 		de: "Abonnent erfolgreich entfernt.",
@@ -4497,7 +4497,7 @@ export const pageLabels = {
 	},
 	"settings.importComplete": {
 		en: "Import complete — {count} added to Listmonk.",
-		ar: "Import complete — {count} added to Listmonk.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اكتمل الاستيراد — تمت إضافة {count} إلى Listmonk.",
 		es: "Importación completada — {count} añadidos a Listmonk.",
 		fr: "Importation terminée — {count} ajoutés à Listmonk.",
 		de: "Import abgeschlossen — {count} zu Listmonk hinzugefügt.",
@@ -4509,7 +4509,7 @@ export const pageLabels = {
 	},
 	"settings.subscribersKicker": {
 		en: "Subscribers",
-		ar: "Subscribers", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المشتركون",
 		es: "Suscriptores",
 		fr: "Abonnés",
 		de: "Abonnenten",
@@ -4521,7 +4521,7 @@ export const pageLabels = {
 	},
 	"settings.newsletterSubscribers": {
 		en: "Newsletter subscribers",
-		ar: "Newsletter subscribers", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مشتركو النشرة البريدية",
 		es: "Suscriptores del boletín",
 		fr: "Abonnés à la newsletter",
 		de: "Newsletter-Abonnenten",
@@ -4533,7 +4533,7 @@ export const pageLabels = {
 	},
 	"settings.subscribersDescBefore": {
 		en: "Subscribers are managed via Listmonk. Configure ",
-		ar: "Subscribers are managed via Listmonk. Configure ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تُدار الاشتراكات عبر Listmonk. اضبط ",
 		es: "Los suscriptores se gestionan a través de Listmonk. Configure ",
 		fr: "Les abonnés sont gérés via Listmonk. Configurez ",
 		de: "Abonnenten werden über Listmonk verwaltet. Konfigurieren Sie ",
@@ -4545,7 +4545,7 @@ export const pageLabels = {
 	},
 	"settings.subscribersDescAfter": {
 		en: " environment variables to enable list management.",
-		ar: " environment variables to enable list management.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: " متغيرات البيئة لتفعيل إدارة القوائم.",
 		es: " variables de entorno para habilitar la gestión de listas.",
 		fr: " des variables d'environnement pour activer la gestion des listes.",
 		de: " Umgebungsvariablen, um die Listenverwaltung zu aktivieren.",
@@ -4557,7 +4557,7 @@ export const pageLabels = {
 	},
 	"settings.listmonkRequiresEnv": {
 		en: "Subscriber list management requires Listmonk. Configure these environment variables to enable it:",
-		ar: "Subscriber list management requires Listmonk. Configure these environment variables to enable it:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تتطلّب إدارة قائمة المشتركين Listmonk. اضبط متغيرات البيئة هذه لتفعيلها:",
 		es: "La gestión de listas de suscriptores requiere Listmonk. Configure estas variables de entorno para activarla:",
 		fr: "La gestion des listes d'abonnés nécessite Listmonk. Configurez ces variables d'environnement pour l'activer :",
 		de: "Die Verwaltung der Abonnentenliste erfordert Listmonk. Konfigurieren Sie diese Umgebungsvariablen, um sie zu aktivieren:",
@@ -4569,7 +4569,7 @@ export const pageLabels = {
 	},
 	"settings.searchSubscribers": {
 		en: "Search subscribers",
-		ar: "Search subscribers", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البحث في المشتركين",
 		es: "Buscar suscriptores",
 		fr: "Rechercher des abonnés",
 		de: "Abonnenten suchen",
@@ -4581,7 +4581,7 @@ export const pageLabels = {
 	},
 	"settings.searchSubscribersPlaceholder": {
 		en: "Search by email or name…",
-		ar: "Search by email or name…", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ابحث بالبريد الإلكتروني أو الاسم…",
 		es: "Buscar por correo o nombre…",
 		fr: "Rechercher par e-mail ou nom…",
 		de: "Nach E-Mail oder Name suchen…",
@@ -4593,7 +4593,7 @@ export const pageLabels = {
 	},
 	"settings.searchButton": {
 		en: "Search",
-		ar: "Search", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بحث",
 		es: "Buscar",
 		fr: "Rechercher",
 		de: "Suchen",
@@ -4605,7 +4605,7 @@ export const pageLabels = {
 	},
 	"settings.clearButton": {
 		en: "Clear",
-		ar: "Clear", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسح",
 		es: "Limpiar",
 		fr: "Effacer",
 		de: "Leeren",
@@ -4617,7 +4617,7 @@ export const pageLabels = {
 	},
 	"settings.noSubscribersFound": {
 		en: "No subscribers found.",
-		ar: "No subscribers found.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لم يُعثر على مشتركين.",
 		es: "No se encontraron suscriptores.",
 		fr: "Aucun abonné trouvé.",
 		de: "Keine Abonnenten gefunden.",
@@ -4629,7 +4629,7 @@ export const pageLabels = {
 	},
 	"settings.subscriberCountSingular": {
 		en: "{count} subscriber",
-		ar: "{count} subscriber", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "{count} مشترك",
 		es: "{count} suscriptor",
 		fr: "{count} abonné",
 		de: "{count} Abonnent",
@@ -4641,7 +4641,7 @@ export const pageLabels = {
 	},
 	"settings.subscriberCountPlural": {
 		en: "{count} subscribers",
-		ar: "{count} subscribers", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "{count} مشترك",
 		es: "{count} suscriptores",
 		fr: "{count} abonnés",
 		de: "{count} Abonnenten",
@@ -4664,7 +4664,7 @@ export const pageLabels = {
 	},
 	"settings.colEmail": {
 		en: "Email",
-		ar: "Email", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البريد الإلكتروني",
 		es: "Correo electrónico",
 		fr: "E-mail",
 		de: "E-Mail",
@@ -4676,7 +4676,7 @@ export const pageLabels = {
 	},
 	"settings.colName": {
 		en: "Name",
-		ar: "Name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الاسم",
 		es: "Nombre",
 		fr: "Nom",
 		de: "Name",
@@ -4688,7 +4688,7 @@ export const pageLabels = {
 	},
 	"settings.colSubscribed": {
 		en: "Subscribed",
-		ar: "Subscribed", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مشترَك",
 		es: "Suscrito",
 		fr: "Abonné",
 		de: "Abonniert",
@@ -4700,7 +4700,7 @@ export const pageLabels = {
 	},
 	"settings.viewAction": {
 		en: "View",
-		ar: "View", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عرض",
 		es: "Ver",
 		fr: "Voir",
 		de: "Anzeigen",
@@ -4712,7 +4712,7 @@ export const pageLabels = {
 	},
 	"settings.subscriberPagesLabel": {
 		en: "Subscriber pages",
-		ar: "Subscriber pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحات المشتركين",
 		es: "Páginas de suscriptores",
 		fr: "Pages des abonnés",
 		de: "Abonnentenseiten",
@@ -4724,7 +4724,7 @@ export const pageLabels = {
 	},
 	"settings.previous": {
 		en: "Previous",
-		ar: "Previous", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "السابق",
 		es: "Anterior",
 		fr: "Précédent",
 		de: "Zurück",
@@ -4736,7 +4736,7 @@ export const pageLabels = {
 	},
 	"settings.next": {
 		en: "Next",
-		ar: "Next", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التالي",
 		es: "Siguiente",
 		fr: "Suivant",
 		de: "Weiter",
@@ -4748,7 +4748,7 @@ export const pageLabels = {
 	},
 	"settings.pageInfo": {
 		en: "Page {page} of {total}",
-		ar: "Page {page} of {total}", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحة {page} من {total}",
 		es: "Página {page} de {total}",
 		fr: "Page {page} sur {total}",
 		de: "Seite {page} von {total}",
@@ -4760,7 +4760,7 @@ export const pageLabels = {
 	},
 	"settings.migrationKicker": {
 		en: "Migration",
-		ar: "Migration", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الترحيل",
 		es: "Migración",
 		fr: "Migration",
 		de: "Migration",
@@ -4772,7 +4772,7 @@ export const pageLabels = {
 	},
 	"settings.importMailchimp": {
 		en: "Import from Mailchimp",
-		ar: "Import from Mailchimp", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استيراد من Mailchimp",
 		es: "Importar desde Mailchimp",
 		fr: "Importer depuis Mailchimp",
 		de: "Aus Mailchimp importieren",
@@ -4784,7 +4784,7 @@ export const pageLabels = {
 	},
 	"settings.importMailchimpDescBefore": {
 		en: "Export your Mailchimp audience as a CSV (Mailchimp dashboard → Audience → Export as CSV), then upload it here to bulk-import subscribers into Listmonk. Required columns: ",
-		ar: "Export your Mailchimp audience as a CSV (Mailchimp dashboard → Audience → Export as CSV), then upload it here to bulk-import subscribers into Listmonk. Required columns: ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صدِّر جمهور Mailchimp بصيغة CSV (لوحة Mailchimp → Audience → Export as CSV)، ثم ارفعه هنا لاستيراد المشتركين بالجملة إلى Listmonk. الأعمدة المطلوبة: ",
 		es: "Exporte su audiencia de Mailchimp como CSV (panel de Mailchimp → Audiencia → Exportar como CSV), luego cárguelo aquí para importar masivamente suscriptores a Listmonk. Columnas requeridas: ",
 		fr: "Exportez votre audience Mailchimp au format CSV (tableau de bord Mailchimp → Audience → Exporter en CSV), puis téléchargez-le ici pour importer en masse des abonnés dans Listmonk. Colonnes requises : ",
 		de: "Exportieren Sie Ihre Mailchimp-Zielgruppe als CSV (Mailchimp-Dashboard → Zielgruppe → Als CSV exportieren) und laden Sie sie dann hier hoch, um Abonnenten in großen Mengen in Listmonk zu importieren. Erforderliche Spalten: ",
@@ -4796,7 +4796,7 @@ export const pageLabels = {
 	},
 	"settings.importMailchimpDescOptional": {
 		en: ". Optional: ",
-		ar: ". Optional: ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: ". اختياري: ",
 		es: ". Opcionales: ",
 		fr: ". Facultatives : ",
 		de: ". Optional: ",
@@ -4808,7 +4808,7 @@ export const pageLabels = {
 	},
 	"settings.mailchimpFile": {
 		en: "Mailchimp audience CSV",
-		ar: "Mailchimp audience CSV", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملف CSV لجمهور Mailchimp",
 		es: "CSV de audiencia de Mailchimp",
 		fr: "CSV d'audience Mailchimp",
 		de: "Mailchimp-Zielgruppen-CSV",
@@ -4820,7 +4820,7 @@ export const pageLabels = {
 	},
 	"settings.mailchimpFileAria": {
 		en: "Mailchimp audience CSV file",
-		ar: "Mailchimp audience CSV file", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملف CSV لجمهور Mailchimp",
 		es: "Archivo CSV de audiencia de Mailchimp",
 		fr: "Fichier CSV d'audience Mailchimp",
 		de: "Mailchimp-Zielgruppen-CSV-Datei",
@@ -4832,7 +4832,7 @@ export const pageLabels = {
 	},
 	"settings.importSubscribersBtn": {
 		en: "Import subscribers",
-		ar: "Import subscribers", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استيراد المشتركين",
 		es: "Importar suscriptores",
 		fr: "Importer les abonnés",
 		de: "Abonnenten importieren",
@@ -4844,7 +4844,7 @@ export const pageLabels = {
 	},
 	"settings.uploading": {
 		en: "Uploading…",
-		ar: "Uploading…", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جارٍ الرفع…",
 		es: "Subiendo…",
 		fr: "Téléversement…",
 		de: "Wird hochgeladen…",
@@ -4856,7 +4856,7 @@ export const pageLabels = {
 	},
 	"settings.importingAria": {
 		en: "Importing subscribers…",
-		ar: "Importing subscribers…", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جارٍ استيراد المشتركين…",
 		es: "Importando suscriptores…",
 		fr: "Importation des abonnés…",
 		de: "Abonnenten werden importiert…",
@@ -4868,7 +4868,7 @@ export const pageLabels = {
 	},
 	"settings.contentMigrationKicker": {
 		en: "Content migration",
-		ar: "Content migration", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ترحيل المحتوى",
 		es: "Migración de contenido",
 		fr: "Migration de contenu",
 		de: "Inhaltsmigration",
@@ -4880,7 +4880,7 @@ export const pageLabels = {
 	},
 	"settings.importContent": {
 		en: "Import content",
-		ar: "Import content", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استيراد المحتوى",
 		es: "Importar contenido",
 		fr: "Importer du contenu",
 		de: "Inhalt importieren",
@@ -4892,7 +4892,7 @@ export const pageLabels = {
 	},
 	"settings.importContentDesc": {
 		en: "Import content from another platform. Imports are non-destructive — existing content is not modified unless you explicitly apply changes.",
-		ar: "Import content from another platform. Imports are non-destructive — existing content is not modified unless you explicitly apply changes.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استورد المحتوى من منصة أخرى. عمليات الاستيراد غير مدمِّرة — لا يُعدَّل المحتوى الحالي ما لم تطبّق التغييرات صراحةً.",
 		es: "Importe contenido de otra plataforma. Las importaciones no son destructivas: el contenido existente no se modifica a menos que aplique cambios explícitamente.",
 		fr: "Importez du contenu depuis une autre plateforme. Les importations sont non destructives — le contenu existant n'est pas modifié sauf si vous appliquez explicitement les changements.",
 		de: "Importieren Sie Inhalte von einer anderen Plattform. Importe sind nicht destruktiv — bestehende Inhalte werden nicht geändert, sofern Sie die Änderungen nicht ausdrücklich anwenden.",
@@ -4904,7 +4904,7 @@ export const pageLabels = {
 	},
 	"settings.wordpress": {
 		en: "WordPress",
-		ar: "WordPress", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "WordPress",
 		es: "WordPress",
 		fr: "WordPress",
 		de: "WordPress",
@@ -4916,7 +4916,7 @@ export const pageLabels = {
 	},
 	"settings.wordpressDesc": {
 		en: "Import from a WordPress XML export file or a live WordPress site URL. Imports posts, pages, media, authors, and taxonomies.",
-		ar: "Import from a WordPress XML export file or a live WordPress site URL. Imports posts, pages, media, authors, and taxonomies.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استورد من ملف XML مصدَّر من WordPress أو من رابط موقع WordPress مباشر. يستورد المنشورات والصفحات والوسائط والمؤلفين والتصنيفات.",
 		es: "Importe desde un archivo XML de exportación de WordPress o una URL de sitio WordPress en vivo. Importa publicaciones, páginas, medios, autores y taxonomías.",
 		fr: "Importez depuis un fichier d'export XML WordPress ou une URL de site WordPress en direct. Importe les articles, pages, médias, auteurs et taxonomies.",
 		de: "Aus einer WordPress-XML-Exportdatei oder einer Live-WordPress-Website-URL importieren. Importiert Beiträge, Seiten, Medien, Autoren und Taxonomien.",
@@ -4928,7 +4928,7 @@ export const pageLabels = {
 	},
 	"settings.setupWordpressImport": {
 		en: "Set up WordPress import →",
-		ar: "Set up WordPress import →", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إعداد استيراد WordPress ←",
 		es: "Configurar importación de WordPress →",
 		fr: "Configurer l'import WordPress →",
 		de: "WordPress-Import einrichten →",
@@ -4940,7 +4940,7 @@ export const pageLabels = {
 	},
 	"settings.wix": {
 		en: "Wix",
-		ar: "Wix", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "Wix",
 		es: "Wix",
 		fr: "Wix",
 		de: "Wix",
@@ -4952,7 +4952,7 @@ export const pageLabels = {
 	},
 	"settings.wixDesc": {
 		en: "Import from a Wix CSV export or a live Wix site URL. Imports blog posts, pages, authors, and media.",
-		ar: "Import from a Wix CSV export or a live Wix site URL. Imports blog posts, pages, authors, and media.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استورد من ملف CSV مصدَّر من Wix أو من رابط موقع Wix مباشر. يستورد منشورات المدوّنة والصفحات والمؤلفين والوسائط.",
 		es: "Importe desde una exportación CSV de Wix o una URL de sitio Wix en vivo. Importa publicaciones de blog, páginas, autores y medios.",
 		fr: "Importez depuis un export CSV Wix ou une URL de site Wix en direct. Importe les articles de blog, pages, auteurs et médias.",
 		de: "Aus einem Wix-CSV-Export oder einer Live-Wix-Website-URL importieren. Importiert Blogbeiträge, Seiten, Autoren und Medien.",
@@ -4964,7 +4964,7 @@ export const pageLabels = {
 	},
 	"settings.setupWixImport": {
 		en: "Set up Wix import →",
-		ar: "Set up Wix import →", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إعداد استيراد Wix ←",
 		es: "Configurar importación de Wix →",
 		fr: "Configurer l'import Wix →",
 		de: "Wix-Import einrichten →",
@@ -4976,7 +4976,7 @@ export const pageLabels = {
 	},
 	"settings.webCrawl": {
 		en: "Web crawl",
-		ar: "Web crawl", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "زحف الويب",
 		es: "Rastreo web",
 		fr: "Exploration Web",
 		de: "Webcrawl",
@@ -4988,7 +4988,7 @@ export const pageLabels = {
 	},
 	"settings.webCrawlDesc": {
 		en: "Crawl any publicly accessible website and import its pages as content records. Useful for static sites without an export format.",
-		ar: "Crawl any publicly accessible website and import its pages as content records. Useful for static sites without an export format.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ازحف إلى أي موقع متاح للعموم واستورد صفحاته كسجلات محتوى. مفيد للمواقع الثابتة التي لا يتوفّر لها صيغة تصدير.",
 		es: "Rastree cualquier sitio web público e importe sus páginas como registros de contenido. Útil para sitios estáticos sin un formato de exportación.",
 		fr: "Explorez tout site web publiquement accessible et importez ses pages comme enregistrements de contenu. Utile pour les sites statiques sans format d'export.",
 		de: "Crawlen Sie eine öffentlich zugängliche Website und importieren Sie ihre Seiten als Inhaltsdatensätze. Nützlich für statische Websites ohne Exportformat.",
@@ -5000,7 +5000,7 @@ export const pageLabels = {
 	},
 	"settings.setupCrawlImport": {
 		en: "Set up crawl import →",
-		ar: "Set up crawl import →", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إعداد استيراد الزحف ←",
 		es: "Configurar importación por rastreo →",
 		fr: "Configurer l'import par exploration →",
 		de: "Crawl-Import einrichten →",
@@ -5012,7 +5012,7 @@ export const pageLabels = {
 	},
 	"settings.importNoteBefore": {
 		en: "All imports run as CLI commands under the hood. The CLI is available via ",
-		ar: "All imports run as CLI commands under the hood. The CLI is available via ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعمل كل عمليات الاستيراد كأوامر CLI داخليًا. تتوفّر أداة CLI عبر ",
 		es: "Todas las importaciones se ejecutan como comandos CLI internamente. La CLI está disponible vía ",
 		fr: "Toutes les importations s'exécutent en tant que commandes CLI en interne. La CLI est disponible via ",
 		de: "Alle Importe werden intern als CLI-Befehle ausgeführt. Die CLI ist verfügbar über ",
@@ -5024,7 +5024,7 @@ export const pageLabels = {
 	},
 	"settings.importNoteAfter": {
 		en: ". This wizard generates the correct command for your configuration.",
-		ar: ". This wizard generates the correct command for your configuration.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: ". يولّد هذا المعالج الأمر الصحيح وفقًا لإعداداتك.",
 		es: ". Este asistente genera el comando correcto para su configuración.",
 		fr: ". Cet assistant génère la commande correcte pour votre configuration.",
 		de: ". Dieser Assistent erzeugt den passenden Befehl für Ihre Konfiguration.",
@@ -5036,7 +5036,7 @@ export const pageLabels = {
 	},
 	"settings.subErrorLoadingList": {
 		en: "Could not load subscriber list. Check your LISTMONK_* environment variables.",
-		ar: "Could not load subscriber list. Check your LISTMONK_* environment variables.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعذّر تحميل قائمة المشتركين. تحقّق من متغيرات البيئة LISTMONK_*.",
 		es: "No se pudo cargar la lista de suscriptores. Verifique sus variables de entorno LISTMONK_*.",
 		fr: "Impossible de charger la liste des abonnés. Vérifiez vos variables d'environnement LISTMONK_*.",
 		de: "Abonnentenliste konnte nicht geladen werden. Überprüfen Sie Ihre LISTMONK_*-Umgebungsvariablen.",
@@ -5048,7 +5048,7 @@ export const pageLabels = {
 	},
 	"users.title": {
 		en: "Users",
-		ar: "Users", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المستخدمون",
 		es: "Usuarios",
 		fr: "Utilisateurs",
 		de: "Benutzer",
@@ -5060,7 +5060,7 @@ export const pageLabels = {
 	},
 	"users.description": {
 		en: "Manage team members, roles, and access state.",
-		ar: "Manage team members, roles, and access state.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر أعضاء الفريق والأدوار وحالة الوصول.",
 		es: "Gestione miembros del equipo, roles y estado de acceso.",
 		fr: "Gérez les membres de l'équipe, les rôles et l'état d'accès.",
 		de: "Verwalten Sie Teammitglieder, Rollen und Zugriffsstatus.",
@@ -5072,7 +5072,7 @@ export const pageLabels = {
 	},
 	"users.partialNotice": {
 		en: "Some user-management data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some user-management data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات إدارة المستخدمين غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de gestión de usuarios no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de gestion des utilisateurs sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Benutzerverwaltungsdaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -5084,7 +5084,7 @@ export const pageLabels = {
 	},
 	"users.invitationIssued": {
 		en: "The invitation was issued successfully.",
-		ar: "The invitation was issued successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم إصدار الدعوة بنجاح.",
 		es: "La invitación se emitió con éxito.",
 		fr: "L'invitation a été émise avec succès.",
 		de: "Die Einladung wurde erfolgreich ausgestellt.",
@@ -5096,7 +5096,7 @@ export const pageLabels = {
 	},
 	"users.userCreatedNoEmail": {
 		en: "User created. Email delivery is in preview mode — no invitation email was sent. Use the link below to share the invite manually.",
-		ar: "User created. Email delivery is in preview mode — no invitation email was sent. Use the link below to share the invite manually.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم إنشاء المستخدم. توصيل البريد في وضع المعاينة — لم يُرسَل بريد دعوة. استخدِم الرابط أدناه لمشاركة الدعوة يدويًا.",
 		es: "Usuario creado. La entrega de correo está en modo de vista previa: no se envió correo de invitación. Use el enlace de abajo para compartir la invitación manualmente.",
 		fr: "Utilisateur créé. La distribution d'e-mails est en mode aperçu : aucun e-mail d'invitation n'a été envoyé. Utilisez le lien ci-dessous pour partager l'invitation manuellement.",
 		de: "Benutzer erstellt. E-Mail-Zustellung befindet sich im Vorschaumodus — keine Einladungs-E-Mail wurde gesendet. Verwenden Sie den unten stehenden Link, um die Einladung manuell zu teilen.",
@@ -5108,7 +5108,7 @@ export const pageLabels = {
 	},
 	"users.userSuspended": {
 		en: "The admin user was suspended successfully.",
-		ar: "The admin user was suspended successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تعليق مستخدم الإدارة بنجاح.",
 		es: "El usuario administrador fue suspendido con éxito.",
 		fr: "L'utilisateur administrateur a été suspendu avec succès.",
 		de: "Der Admin-Benutzer wurde erfolgreich gesperrt.",
@@ -5120,7 +5120,7 @@ export const pageLabels = {
 	},
 	"users.userRestored": {
 		en: "The admin user was restored successfully.",
-		ar: "The admin user was restored successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم استرداد مستخدم الإدارة بنجاح.",
 		es: "El usuario administrador fue restaurado con éxito.",
 		fr: "L'utilisateur administrateur a été restauré avec succès.",
 		de: "Der Admin-Benutzer wurde erfolgreich wiederhergestellt.",
@@ -5132,7 +5132,7 @@ export const pageLabels = {
 	},
 	"users.invitationLink": {
 		en: "Invitation link: ",
-		ar: "Invitation link: ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط الدعوة: ",
 		es: "Enlace de invitación: ",
 		fr: "Lien d'invitation : ",
 		de: "Einladungslink: ",
@@ -5144,7 +5144,7 @@ export const pageLabels = {
 	},
 	"users.resetLinkPrefix": {
 		en: "Password reset link issued: ",
-		ar: "Password reset link issued: ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم إصدار رابط إعادة تعيين كلمة المرور: ",
 		es: "Enlace de restablecimiento de contraseña emitido: ",
 		fr: "Lien de réinitialisation du mot de passe émis : ",
 		de: "Link zum Zurücksetzen des Passworts ausgestellt: ",
@@ -5156,7 +5156,7 @@ export const pageLabels = {
 	},
 	"users.intro": {
 		en: "User management is admin-only. New accounts are invited first and set their own password through a single-use link.",
-		ar: "User management is admin-only. New accounts are invited first and set their own password through a single-use link.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إدارة المستخدمين متاحة للمسؤولين فقط. تُدعى الحسابات الجديدة أولًا وتحدّد كلمة المرور عبر رابط أحادي الاستخدام.",
 		es: "La gestión de usuarios es solo para administradores. Las cuentas nuevas se invitan primero y configuran su propia contraseña a través de un enlace de un solo uso.",
 		fr: "La gestion des utilisateurs est réservée aux administrateurs. Les nouveaux comptes sont d'abord invités et définissent leur propre mot de passe via un lien à usage unique.",
 		de: "Die Benutzerverwaltung ist nur für Administratoren. Neue Konten werden zuerst eingeladen und legen ihr eigenes Passwort über einen Einmal-Link fest.",
@@ -5168,7 +5168,7 @@ export const pageLabels = {
 	},
 	"users.totalUsers": {
 		en: "Total users",
-		ar: "Total users", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجمالي المستخدمين",
 		es: "Usuarios totales",
 		fr: "Utilisateurs totaux",
 		de: "Gesamtnutzer",
@@ -5180,7 +5180,7 @@ export const pageLabels = {
 	},
 	"users.totalUsersDesc": {
 		en: "Managed admin and editor accounts.",
-		ar: "Managed admin and editor accounts.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حسابات الإدارة والمحرّرين المُدارة.",
 		es: "Cuentas de administrador y editor gestionadas.",
 		fr: "Comptes administrateur et éditeur gérés.",
 		de: "Verwaltete Admin- und Editor-Konten.",
@@ -5192,7 +5192,7 @@ export const pageLabels = {
 	},
 	"users.pendingInvites": {
 		en: "Pending invites",
-		ar: "Pending invites", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "دعوات معلَّقة",
 		es: "Invitaciones pendientes",
 		fr: "Invitations en attente",
 		de: "Ausstehende Einladungen",
@@ -5204,7 +5204,7 @@ export const pageLabels = {
 	},
 	"users.pendingInvitesDesc": {
 		en: "Invitations that have not been accepted yet.",
-		ar: "Invitations that have not been accepted yet.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الدعوات التي لم تُقبَل بعد.",
 		es: "Invitaciones que aún no han sido aceptadas.",
 		fr: "Invitations qui n'ont pas encore été acceptées.",
 		de: "Einladungen, die noch nicht angenommen wurden.",
@@ -5216,7 +5216,7 @@ export const pageLabels = {
 	},
 	"users.accessControlKicker": {
 		en: "Access Control",
-		ar: "Access Control", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التحكم بالوصول",
 		es: "Control de acceso",
 		fr: "Contrôle d'accès",
 		de: "Zugriffskontrolle",
@@ -5228,7 +5228,7 @@ export const pageLabels = {
 	},
 	"users.currentUsers": {
 		en: "Current Users",
-		ar: "Current Users", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المستخدمون الحاليون",
 		es: "Usuarios actuales",
 		fr: "Utilisateurs actuels",
 		de: "Aktuelle Benutzer",
@@ -5240,7 +5240,7 @@ export const pageLabels = {
 	},
 	"users.currentUsersDesc": {
 		en: "Manage roles, suspend access, and issue one-time reset links from the same table.",
-		ar: "Manage roles, suspend access, and issue one-time reset links from the same table.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر الأدوار وعلِّق الوصول وأصدِر روابط إعادة تعيين أحادية الاستخدام من الجدول ذاته.",
 		es: "Gestione roles, suspenda accesos y emita enlaces de restablecimiento de un solo uso desde la misma tabla.",
 		fr: "Gérez les rôles, suspendez l'accès et émettez des liens de réinitialisation à usage unique depuis le même tableau.",
 		de: "Verwalten Sie Rollen, sperren Sie den Zugriff und geben Sie Einmal-Reset-Links in derselben Tabelle aus.",
@@ -5252,7 +5252,7 @@ export const pageLabels = {
 	},
 	"users.adminUsersAria": {
 		en: "Admin users",
-		ar: "Admin users", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مستخدمو الإدارة",
 		es: "Usuarios administradores",
 		fr: "Utilisateurs administrateurs",
 		de: "Admin-Benutzer",
@@ -5264,7 +5264,7 @@ export const pageLabels = {
 	},
 	"users.colName": {
 		en: "Name",
-		ar: "Name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الاسم",
 		es: "Nombre",
 		fr: "Nom",
 		de: "Name",
@@ -5276,7 +5276,7 @@ export const pageLabels = {
 	},
 	"users.colEmail": {
 		en: "Email",
-		ar: "Email", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البريد الإلكتروني",
 		es: "Correo electrónico",
 		fr: "E-mail",
 		de: "E-Mail",
@@ -5288,7 +5288,7 @@ export const pageLabels = {
 	},
 	"users.colRole": {
 		en: "Role",
-		ar: "Role", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الدور",
 		es: "Rol",
 		fr: "Rôle",
 		de: "Rolle",
@@ -5300,7 +5300,7 @@ export const pageLabels = {
 	},
 	"users.colJoined": {
 		en: "Joined",
-		ar: "Joined", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "انضمّ",
 		es: "Se unió",
 		fr: "A rejoint",
 		de: "Beigetreten",
@@ -5312,7 +5312,7 @@ export const pageLabels = {
 	},
 	"users.statusSuspended": {
 		en: "Suspended",
-		ar: "Suspended", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "معلَّق",
 		es: "Suspendido",
 		fr: "Suspendu",
 		de: "Gesperrt",
@@ -5324,7 +5324,7 @@ export const pageLabels = {
 	},
 	"users.statusInvited": {
 		en: "Invited",
-		ar: "Invited", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تمت الدعوة",
 		es: "Invitado",
 		fr: "Invité",
 		de: "Eingeladen",
@@ -5336,7 +5336,7 @@ export const pageLabels = {
 	},
 	"users.statusActive": {
 		en: "Active",
-		ar: "Active", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نشِط",
 		es: "Activo",
 		fr: "Actif",
 		de: "Aktiv",
@@ -5348,7 +5348,7 @@ export const pageLabels = {
 	},
 	"users.unsuspend": {
 		en: "Unsuspend",
-		ar: "Unsuspend", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء التعليق",
 		es: "Reactivar",
 		fr: "Réactiver",
 		de: "Entsperren",
@@ -5360,7 +5360,7 @@ export const pageLabels = {
 	},
 	"users.suspend": {
 		en: "Suspend",
-		ar: "Suspend", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعليق",
 		es: "Suspender",
 		fr: "Suspendre",
 		de: "Sperren",
@@ -5372,7 +5372,7 @@ export const pageLabels = {
 	},
 	"users.resetLinkBtn": {
 		en: "Reset Link",
-		ar: "Reset Link", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط الإعادة",
 		es: "Enlace de restablecimiento",
 		fr: "Lien de réinitialisation",
 		de: "Reset-Link",
@@ -5384,7 +5384,7 @@ export const pageLabels = {
 	},
 	"users.createAccessKicker": {
 		en: "Create Access",
-		ar: "Create Access", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إنشاء وصول",
 		es: "Crear acceso",
 		fr: "Créer un accès",
 		de: "Zugang erstellen",
@@ -5396,7 +5396,7 @@ export const pageLabels = {
 	},
 	"users.inviteUser": {
 		en: "Invite User",
-		ar: "Invite User", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "دعوة مستخدم",
 		es: "Invitar usuario",
 		fr: "Inviter un utilisateur",
 		de: "Benutzer einladen",
@@ -5408,7 +5408,7 @@ export const pageLabels = {
 	},
 	"users.inviteUserDesc": {
 		en: "Invite a team member and let them set their password from a single-use link.",
-		ar: "Invite a team member and let them set their password from a single-use link.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ادعُ أحد أعضاء الفريق ودَعه يُحدِّد كلمة المرور عبر رابط أحادي الاستخدام.",
 		es: "Invite a un miembro del equipo y permita que establezca su contraseña desde un enlace de un solo uso.",
 		fr: "Invitez un membre de l'équipe et laissez-le définir son mot de passe via un lien à usage unique.",
 		de: "Laden Sie ein Teammitglied ein und lassen Sie es sein Passwort über einen Einmal-Link festlegen.",
@@ -5420,7 +5420,7 @@ export const pageLabels = {
 	},
 	"users.fullName": {
 		en: "Full Name",
-		ar: "Full Name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الاسم الكامل",
 		es: "Nombre completo",
 		fr: "Nom complet",
 		de: "Vollständiger Name",
@@ -5432,7 +5432,7 @@ export const pageLabels = {
 	},
 	"users.email": {
 		en: "Email",
-		ar: "Email", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البريد الإلكتروني",
 		es: "Correo electrónico",
 		fr: "E-mail",
 		de: "E-Mail",
@@ -5444,7 +5444,7 @@ export const pageLabels = {
 	},
 	"users.role": {
 		en: "Role",
-		ar: "Role", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الدور",
 		es: "Rol",
 		fr: "Rôle",
 		de: "Rolle",
@@ -5456,7 +5456,7 @@ export const pageLabels = {
 	},
 	"users.roleEditor": {
 		en: "Editor",
-		ar: "Editor", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "محرّر",
 		es: "Editor",
 		fr: "Éditeur",
 		de: "Editor",
@@ -5468,7 +5468,7 @@ export const pageLabels = {
 	},
 	"users.roleAdmin": {
 		en: "Admin",
-		ar: "Admin", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإدارة",
 		es: "Administrador",
 		fr: "Admin",
 		de: "Admin",
@@ -5480,7 +5480,7 @@ export const pageLabels = {
 	},
 	"users.sendInvitation": {
 		en: "Send Invitation",
-		ar: "Send Invitation", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إرسال الدعوة",
 		es: "Enviar invitación",
 		fr: "Envoyer l'invitation",
 		de: "Einladung senden",
@@ -5492,7 +5492,7 @@ export const pageLabels = {
 	},
 	"users.inviteNote": {
 		en: "The invited user receives a single-use setup link. In non-production mode, the link is echoed above for local review.",
-		ar: "The invited user receives a single-use setup link. In non-production mode, the link is echoed above for local review.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يستلم المستخدم المدعو رابط إعداد أحادي الاستخدام. في الوضع غير الإنتاجي، يُعرض الرابط أعلاه للمراجعة المحلية.",
 		es: "El usuario invitado recibe un enlace de configuración de un solo uso. En modo no productivo, el enlace se muestra arriba para revisión local.",
 		fr: "L'utilisateur invité reçoit un lien de configuration à usage unique. En mode non production, le lien est affiché ci-dessus pour une vérification locale.",
 		de: "Der eingeladene Benutzer erhält einen Einmal-Einrichtungslink. Im Nicht-Produktionsmodus wird der Link oben zur lokalen Überprüfung angezeigt.",
@@ -5504,7 +5504,7 @@ export const pageLabels = {
 	},
 	"users.userAndAccessAudit": {
 		en: "User And Access Audit",
-		ar: "User And Access Audit", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تدقيق المستخدمين والوصول",
 		es: "Auditoría de usuario y acceso",
 		fr: "Audit utilisateur et accès",
 		de: "Benutzer- und Zugriffsprüfung",
@@ -5516,7 +5516,7 @@ export const pageLabels = {
 	},
 	"users.gdprKicker": {
 		en: "GDPR / Right of Erasure",
-		ar: "GDPR / Right of Erasure", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اللائحة العامة لحماية البيانات / الحق في المحو",
 		es: "GDPR / Derecho de supresión",
 		fr: "GDPR / Droit à l'effacement",
 		de: "GDPR / Recht auf Löschung",
@@ -5528,7 +5528,7 @@ export const pageLabels = {
 	},
 	"users.purgeUserData": {
 		en: "Purge User Data",
-		ar: "Purge User Data", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تطهير بيانات المستخدم",
 		es: "Eliminar datos del usuario",
 		fr: "Purger les données utilisateur",
 		de: "Benutzerdaten löschen",
@@ -5540,7 +5540,7 @@ export const pageLabels = {
 	},
 	"users.purgeUserDataDesc": {
 		en: "Permanently remove all personal data associated with an email address. This action revokes sessions, anonymises audit log entries, deletes comments and contact submissions, and suspends or deletes the admin account. A JSON export of all affected records is downloaded for your data-subject-request records.",
-		ar: "Permanently remove all personal data associated with an email address. This action revokes sessions, anonymises audit log entries, deletes comments and contact submissions, and suspends or deletes the admin account. A JSON export of all affected records is downloaded for your data-subject-request records.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "احذف نهائيًا جميع البيانات الشخصية المرتبطة ببريد إلكتروني. يلغي هذا الإجراء الجلسات، ويخفي هوية إدخالات سجل التدقيق، ويحذف التعليقات والإفادات المُرسَلة، ويعلّق حساب الإدارة أو يحذفه. يُنزَّل تصدير JSON بجميع السجلات المتأثّرة لسجلات طلبات أصحاب البيانات.",
 		es: "Elimina permanentemente todos los datos personales asociados a una dirección de correo. Esta acción revoca sesiones, anonimiza entradas del registro de auditoría, elimina comentarios y envíos de contacto, y suspende o elimina la cuenta admin. Se descarga una exportación JSON de todos los registros afectados para sus solicitudes de datos.",
 		fr: "Supprime définitivement toutes les données personnelles associées à une adresse e-mail. Cette action révoque les sessions, anonymise les entrées du journal d'audit, supprime les commentaires et envois de contact, et suspend ou supprime le compte admin. Un export JSON de tous les enregistrements concernés est téléchargé pour vos demandes de personnes concernées.",
 		de: "Entfernt dauerhaft alle persönlichen Daten, die mit einer E-Mail-Adresse verknüpft sind. Diese Aktion widerruft Sitzungen, anonymisiert Audit-Log-Einträge, löscht Kommentare und Kontaktanfragen und sperrt oder löscht das Admin-Konto. Ein JSON-Export aller betroffenen Datensätze wird für Ihre Betroffenenanfragen heruntergeladen.",
@@ -5552,7 +5552,7 @@ export const pageLabels = {
 	},
 	"users.purgeEmailLabel": {
 		en: "Email address to purge",
-		ar: "Email address to purge", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البريد الإلكتروني المراد تطهيره",
 		es: "Correo electrónico a eliminar",
 		fr: "Adresse e-mail à purger",
 		de: "Zu löschende E-Mail-Adresse",
@@ -5564,7 +5564,7 @@ export const pageLabels = {
 	},
 	"users.purgeDeleteCheckbox": {
 		en: "Permanently delete admin account (instead of suspending)",
-		ar: "Permanently delete admin account (instead of suspending)", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف حساب الإدارة نهائيًا (بدل تعليقه)",
 		es: "Eliminar permanentemente la cuenta admin (en lugar de suspender)",
 		fr: "Supprimer définitivement le compte admin (au lieu de suspendre)",
 		de: "Admin-Konto dauerhaft löschen (statt zu sperren)",
@@ -5576,7 +5576,7 @@ export const pageLabels = {
 	},
 	"users.purgeAndDownload": {
 		en: "Purge & Download Report",
-		ar: "Purge & Download Report", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تقرير التطهير والتنزيل",
 		es: "Eliminar y descargar informe",
 		fr: "Purger et télécharger le rapport",
 		de: "Löschen & Bericht herunterladen",
@@ -5588,7 +5588,7 @@ export const pageLabels = {
 	},
 	"users.confirmSuspendTitle": {
 		en: "Suspend user?",
-		ar: "Suspend user?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعليق المستخدم؟",
 		es: "¿Suspender usuario?",
 		fr: "Suspendre l'utilisateur ?",
 		de: "Benutzer sperren?",
@@ -5600,7 +5600,7 @@ export const pageLabels = {
 	},
 	"users.confirmSuspendBefore": {
 		en: "Are you sure you want to suspend ",
-		ar: "Are you sure you want to suspend ", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد تعليق ",
 		es: "¿Está seguro de que desea suspender ",
 		fr: "Êtes-vous sûr de vouloir suspendre ",
 		de: "Möchten Sie wirklich sperren ",
@@ -5612,7 +5612,7 @@ export const pageLabels = {
 	},
 	"users.confirmSuspendAfter": {
 		en: "?",
-		ar: "?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "؟",
 		es: "?",
 		fr: " ?",
 		de: "?",
@@ -5624,7 +5624,7 @@ export const pageLabels = {
 	},
 	"users.confirmSuspendNote": {
 		en: "Suspended users cannot sign in until unsuspended.",
-		ar: "Suspended users cannot sign in until unsuspended.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يستطيع المستخدمون المعلَّقون تسجيل الدخول حتى يُلغى تعليقهم.",
 		es: "Los usuarios suspendidos no pueden iniciar sesión hasta que se reactiven.",
 		fr: "Les utilisateurs suspendus ne peuvent pas se connecter tant qu'ils ne sont pas réactivés.",
 		de: "Gesperrte Benutzer können sich erst nach Entsperrung anmelden.",
@@ -5636,7 +5636,7 @@ export const pageLabels = {
 	},
 	"users.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -5648,7 +5648,7 @@ export const pageLabels = {
 	},
 	"users.suspendUserBtn": {
 		en: "Suspend User",
-		ar: "Suspend User", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعليق المستخدم",
 		es: "Suspender usuario",
 		fr: "Suspendre l'utilisateur",
 		de: "Benutzer sperren",
@@ -5660,7 +5660,7 @@ export const pageLabels = {
 	},
 	"users.confirmPurgeTitle": {
 		en: "Purge all personal data?",
-		ar: "Purge all personal data?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تطهير جميع البيانات الشخصية؟",
 		es: "¿Eliminar todos los datos personales?",
 		fr: "Purger toutes les données personnelles ?",
 		de: "Alle persönlichen Daten löschen?",
@@ -5672,7 +5672,7 @@ export const pageLabels = {
 	},
 	"users.confirmPurgeDesc": {
 		en: "This will permanently erase all personal data for this email. Sessions will be revoked, audit logs anonymised, comments and submissions deleted.",
-		ar: "This will permanently erase all personal data for this email. Sessions will be revoked, audit logs anonymised, comments and submissions deleted.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سيمحو هذا نهائيًا جميع البيانات الشخصية لهذا البريد. ستُلغى الجلسات وتُخفى هوية سجلات التدقيق وتُحذف التعليقات والإفادات.",
 		es: "Esto borrará permanentemente todos los datos personales de este correo. Las sesiones se revocarán, los registros de auditoría se anonimizarán y los comentarios y envíos se eliminarán.",
 		fr: "Cela effacera définitivement toutes les données personnelles de cet e-mail. Les sessions seront révoquées, les journaux d'audit anonymisés, les commentaires et envois supprimés.",
 		de: "Dies löscht dauerhaft alle persönlichen Daten dieser E-Mail. Sitzungen werden widerrufen, Audit-Logs anonymisiert, Kommentare und Einsendungen gelöscht.",
@@ -5684,7 +5684,7 @@ export const pageLabels = {
 	},
 	"users.confirmPurgeWarning": {
 		en: "This action cannot be undone.",
-		ar: "This action cannot be undone.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يمكن التراجع عن هذا الإجراء.",
 		es: "Esta acción no se puede deshacer.",
 		fr: "Cette action ne peut pas être annulée.",
 		de: "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -5696,7 +5696,7 @@ export const pageLabels = {
 	},
 	"users.purgeAndDownloadShort": {
 		en: "Purge & Download",
-		ar: "Purge & Download", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تطهير وتنزيل",
 		es: "Eliminar y descargar",
 		fr: "Purger et télécharger",
 		de: "Löschen & Herunterladen",
@@ -5709,7 +5709,7 @@ export const pageLabels = {
 	// ANCHOR-BATCH-C: route-pages + archives + translations
 	"routePages.title": {
 		en: "Route Table",
-		ar: "Route Table", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جدول المسارات",
 		es: "Tabla de rutas",
 		fr: "Table de routes",
 		de: "Routentabelle",
@@ -5721,7 +5721,7 @@ export const pageLabels = {
 	},
 	"routePages.description": {
 		en: "Technical inventory of route-backed structured pages. Normal page editing should start from Pages.",
-		ar: "Technical inventory of route-backed structured pages. Normal page editing should start from Pages.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'جرد فني للصفحات المنظَّمة المستندة إلى مسار. يجب أن يبدأ تحرير الصفحات الاعتيادية من "الصفحات".',
 		es: "Inventario técnico de páginas estructuradas con rutas. La edición normal debe iniciarse desde Páginas.",
 		fr: "Inventaire technique des pages structurées basées sur des routes. L'édition normale doit commencer depuis Pages.",
 		de: "Technische Bestandsaufnahme routenbasierter strukturierter Seiten. Reguläre Bearbeitung sollte über Seiten beginnen.",
@@ -5733,7 +5733,7 @@ export const pageLabels = {
 	},
 	"routePages.partialResults": {
 		en: "Some route-table data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some route-table data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات جدول المسارات غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de la tabla de rutas no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de la table de routes sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Routentabellendaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -5745,7 +5745,7 @@ export const pageLabels = {
 	},
 	"routePages.securityKicker": {
 		en: "Security",
-		ar: "Security", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الأمان",
 		es: "Seguridad",
 		fr: "Sécurité",
 		de: "Sicherheit",
@@ -5757,7 +5757,7 @@ export const pageLabels = {
 	},
 	"routePages.adminUrlHeading": {
 		en: "Admin URL",
-		ar: "Admin URL", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط الإدارة",
 		es: "URL de administración",
 		fr: "URL d'administration",
 		de: "Admin-URL",
@@ -5769,7 +5769,7 @@ export const pageLabels = {
 	},
 	"routePages.adminUrlIntroPrefix": {
 		en: "The admin area is accessible at",
-		ar: "The admin area is accessible at", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منطقة الإدارة متاحة عبر",
 		es: "El área de administración está disponible en",
 		fr: "L'espace d'administration est accessible à",
 		de: "Der Admin-Bereich ist erreichbar unter",
@@ -5781,7 +5781,7 @@ export const pageLabels = {
 	},
 	"routePages.adminUrlIntroSuffix": {
 		en: "Changing it to a unique path makes it harder for bots to find your login page.",
-		ar: "Changing it to a unique path makes it harder for bots to find your login page.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يصعّب تغييره إلى مسار فريد على الروبوتات العثور على صفحة الدخول.",
 		es: "Cambiarla a una ruta única dificulta que los bots encuentren tu página de inicio de sesión.",
 		fr: "La remplacer par un chemin unique complique la tâche des bots pour trouver votre page de connexion.",
 		de: "Eine eindeutige Adresse erschwert Bots das Auffinden Ihrer Anmeldeseite.",
@@ -5793,7 +5793,7 @@ export const pageLabels = {
 	},
 	"routePages.defaultSlugWarningStrong": {
 		en: "You are using the default admin path",
-		ar: "You are using the default admin path", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تستخدم مسار الإدارة الافتراضي",
 		es: "Estás usando la ruta de administración predeterminada",
 		fr: "Vous utilisez le chemin d'administration par défaut",
 		de: "Sie verwenden den Standard-Admin-Pfad",
@@ -5805,7 +5805,7 @@ export const pageLabels = {
 	},
 	"routePages.defaultSlugWarningRest": {
 		en: "Automated bots routinely target this path. Change it to a unique value to reduce unwanted login attempts.",
-		ar: "Automated bots routinely target this path. Change it to a unique value to reduce unwanted login attempts.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تستهدف الروبوتات الآلية هذا المسار باستمرار. غيِّره إلى قيمة فريدة لتقليل محاولات الدخول غير المرغوبة.",
 		es: "Los bots automatizados atacan habitualmente esta ruta. Cámbiala a un valor único para reducir intentos de inicio de sesión no deseados.",
 		fr: "Les bots automatisés ciblent régulièrement ce chemin. Changez-le en une valeur unique pour réduire les tentatives de connexion indésirables.",
 		de: "Automatisierte Bots greifen diesen Pfad regelmäßig an. Wählen Sie einen eindeutigen Wert, um unerwünschte Anmeldeversuche zu reduzieren.",
@@ -5817,7 +5817,7 @@ export const pageLabels = {
 	},
 	"routePages.slugSavedPrefix": {
 		en: "Admin URL updated. You are now at",
-		ar: "Admin URL updated. You are now at", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تحديث رابط الإدارة. أنت الآن في",
 		es: "URL de administración actualizada. Ahora estás en",
 		fr: "URL d'administration mise à jour. Vous êtes maintenant sur",
 		de: "Admin-URL aktualisiert. Sie befinden sich jetzt unter",
@@ -5829,7 +5829,7 @@ export const pageLabels = {
 	},
 	"routePages.adminUrlPrefixLabel": {
 		en: "Admin URL prefix",
-		ar: "Admin URL prefix", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بادئة رابط الإدارة",
 		es: "Prefijo de URL de administración",
 		fr: "Préfixe de l'URL d'administration",
 		de: "Präfix der Admin-URL",
@@ -5841,7 +5841,7 @@ export const pageLabels = {
 	},
 	"routePages.slugInputTitle": {
 		en: "Lowercase letters, numbers, and hyphens only. Cannot start or end with a hyphen.",
-		ar: "Lowercase letters, numbers, and hyphens only. Cannot start or end with a hyphen.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أحرف صغيرة وأرقام وشرطات فقط. لا يمكن أن يبدأ أو ينتهي بشرطة.",
 		es: "Solo letras minúsculas, números y guiones. No puede empezar ni terminar con guion.",
 		fr: "Lettres minuscules, chiffres et tirets uniquement. Ne peut pas commencer ni se terminer par un tiret.",
 		de: "Nur Kleinbuchstaben, Zahlen und Bindestriche. Darf nicht mit einem Bindestrich beginnen oder enden.",
@@ -5853,7 +5853,7 @@ export const pageLabels = {
 	},
 	"routePages.slugFieldNote": {
 		en: "Lowercase letters, numbers, and hyphens only. Avoid generic paths like",
-		ar: "Lowercase letters, numbers, and hyphens only. Avoid generic paths like", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أحرف صغيرة وأرقام وشرطات فقط. تجنّب المسارات العامة مثل",
 		es: "Solo letras minúsculas, números y guiones. Evita rutas genéricas como",
 		fr: "Lettres minuscules, chiffres et tirets uniquement. Évitez les chemins génériques comme",
 		de: "Nur Kleinbuchstaben, Zahlen und Bindestriche. Vermeiden Sie generische Pfade wie",
@@ -5865,7 +5865,7 @@ export const pageLabels = {
 	},
 	"routePages.slugFieldNoteOr": {
 		en: "or",
-		ar: "or", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أو",
 		es: "o",
 		fr: "ou",
 		de: "oder",
@@ -5877,7 +5877,7 @@ export const pageLabels = {
 	},
 	"routePages.saveAdminUrl": {
 		en: "Save admin URL",
-		ar: "Save admin URL", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ رابط الإدارة",
 		es: "Guardar URL de administración",
 		fr: "Enregistrer l'URL d'administration",
 		de: "Admin-URL speichern",
@@ -5889,7 +5889,7 @@ export const pageLabels = {
 	},
 	"routePages.technicalInventory": {
 		en: "Technical Inventory",
-		ar: "Technical Inventory", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الجرد الفني",
 		es: "Inventario técnico",
 		fr: "Inventaire technique",
 		de: "Technisches Inventar",
@@ -5901,7 +5901,7 @@ export const pageLabels = {
 	},
 	"routePages.structuredRouteInventory": {
 		en: "Structured Route Inventory",
-		ar: "Structured Route Inventory", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جرد المسارات المنظَّمة",
 		es: "Inventario de rutas estructuradas",
 		fr: "Inventaire des routes structurées",
 		de: "Bestandsaufnahme strukturierter Routen",
@@ -5913,7 +5913,7 @@ export const pageLabels = {
 	},
 	"routePages.structuredRouteDesc": {
 		en: "Use this screen for technical route review. Normal editorial work should still start from Pages.",
-		ar: "Use this screen for technical route review. Normal editorial work should still start from Pages.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'استخدِم هذه الشاشة للمراجعة الفنية للمسارات. يجب أن يبدأ العمل التحريري الاعتيادي من "الصفحات".',
 		es: "Usa esta pantalla para la revisión técnica de rutas. El trabajo editorial normal debe iniciarse en Páginas.",
 		fr: "Utilisez cet écran pour la revue technique des routes. Le travail éditorial normal doit toujours commencer depuis Pages.",
 		de: "Nutzen Sie diese Ansicht für technische Routenprüfungen. Reguläre redaktionelle Arbeit sollte weiterhin über Seiten beginnen.",
@@ -5925,7 +5925,7 @@ export const pageLabels = {
 	},
 	"routePages.backToPages": {
 		en: "Back to pages",
-		ar: "Back to pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العودة إلى الصفحات",
 		es: "Volver a páginas",
 		fr: "Retour aux pages",
 		de: "Zurück zu Seiten",
@@ -5937,7 +5937,7 @@ export const pageLabels = {
 	},
 	"routePages.tableAria": {
 		en: "Route pages list",
-		ar: "Route pages list", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة صفحات المسارات",
 		es: "Lista de páginas de rutas",
 		fr: "Liste des pages de route",
 		de: "Liste der Routenseiten",
@@ -5949,7 +5949,7 @@ export const pageLabels = {
 	},
 	"routePages.template": {
 		en: "Template",
-		ar: "Template", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قالب",
 		es: "Plantilla",
 		fr: "Modèle",
 		de: "Vorlage",
@@ -5961,7 +5961,7 @@ export const pageLabels = {
 	},
 	"routePages.ownerEditor": {
 		en: "Owner Editor",
-		ar: "Owner Editor", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "محرّر المالك",
 		es: "Editor propietario",
 		fr: "Éditeur propriétaire",
 		de: "Eigentümer-Editor",
@@ -5973,7 +5973,7 @@ export const pageLabels = {
 	},
 	"routePages.publicView": {
 		en: "Public View",
-		ar: "Public View", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العرض العام",
 		es: "Vista pública",
 		fr: "Vue publique",
 		de: "Öffentliche Ansicht",
@@ -5985,7 +5985,7 @@ export const pageLabels = {
 	},
 	"routePages.pages": {
 		en: "Pages",
-		ar: "Pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات",
 		es: "Páginas",
 		fr: "Pages",
 		de: "Seiten",
@@ -5997,7 +5997,7 @@ export const pageLabels = {
 	},
 	"routePages.openRoute": {
 		en: "Open route",
-		ar: "Open route", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح المسار",
 		es: "Abrir ruta",
 		fr: "Ouvrir la route",
 		de: "Route öffnen",
@@ -6009,7 +6009,7 @@ export const pageLabels = {
 	},
 	"routePages.seeded": {
 		en: "Seeded",
-		ar: "Seeded", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مزروع",
 		es: "Sembrado",
 		fr: "Initialisé",
 		de: "Vorbefüllt",
@@ -6021,7 +6021,7 @@ export const pageLabels = {
 	},
 	"routePages.forbiddenTitle": {
 		en: "Forbidden",
-		ar: "Forbidden", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ممنوع",
 		es: "Prohibido",
 		fr: "Interdit",
 		de: "Verboten",
@@ -6033,7 +6033,7 @@ export const pageLabels = {
 	},
 	"routePages.forbiddenDesc": {
 		en: "This action requires an admin account.",
-		ar: "This action requires an admin account.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول.",
 		es: "Esta acción requiere una cuenta de administración.",
 		fr: "Cette action nécessite un compte administrateur.",
 		de: "Diese Aktion erfordert ein Admin-Konto.",
@@ -6045,7 +6045,7 @@ export const pageLabels = {
 	},
 	"routePages.forbiddenBody": {
 		en: "This action requires an admin account and is hidden from editor-only roles.",
-		ar: "This action requires an admin account and is hidden from editor-only roles.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول وهو مخفي عن الأدوار المحرّرة فقط.",
 		es: "Esta acción requiere una cuenta de administración y está oculta para roles solo de editor.",
 		fr: "Cette action nécessite un compte administrateur et est masquée pour les rôles éditeur uniquement.",
 		de: "Diese Aktion erfordert ein Admin-Konto und ist für reine Editor-Rollen ausgeblendet.",
@@ -6057,7 +6057,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.title": {
 		en: "Edit Route Table Record",
-		ar: "Edit Route Table Record", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل سجل جدول المسارات",
 		es: "Editar registro de tabla de rutas",
 		fr: "Modifier l'entrée de la table de routes",
 		de: "Routentabelleneintrag bearbeiten",
@@ -6069,7 +6069,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.titlePrefix": {
 		en: "Edit Route Page",
-		ar: "Edit Route Page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل صفحة المسار",
 		es: "Editar página de ruta",
 		fr: "Modifier la page de route",
 		de: "Routenseite bearbeiten",
@@ -6081,7 +6081,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.description": {
 		en: "Technical editing for route-backed structured pages. Use Pages for the normal editorial entry point.",
-		ar: "Technical editing for route-backed structured pages. Use Pages for the normal editorial entry point.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'التحرير الفني للصفحات المنظَّمة المستندة إلى مسار. استخدِم "الصفحات" لنقطة الدخول التحريرية الاعتيادية.',
 		es: "Edición técnica para páginas estructuradas con rutas. Usa Páginas como punto de entrada editorial normal.",
 		fr: "Édition technique des pages structurées basées sur des routes. Utilisez Pages comme point d'entrée éditorial normal.",
 		de: "Technische Bearbeitung routenbasierter strukturierter Seiten. Nutzen Sie Seiten als normalen redaktionellen Einstieg.",
@@ -6093,7 +6093,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.breadcrumb": {
 		en: "breadcrumb",
-		ar: "breadcrumb", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسار التنقل",
 		es: "ruta de navegación",
 		fr: "fil d'Ariane",
 		de: "Brotkrumen",
@@ -6105,7 +6105,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.routePagesLink": {
 		en: "Route Pages",
-		ar: "Route Pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحات المسارات",
 		es: "Páginas de rutas",
 		fr: "Pages de route",
 		de: "Routenseiten",
@@ -6117,7 +6117,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.partialResults": {
 		en: "Some route-page data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some route-page data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات صفحات المسارات غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de la página de ruta no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de la page de route sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Routenseiten-Daten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -6129,7 +6129,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.openPublicPage": {
 		en: "Open public page",
-		ar: "Open public page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح الصفحة العامة",
 		es: "Abrir página pública",
 		fr: "Ouvrir la page publique",
 		de: "Öffentliche Seite öffnen",
@@ -6141,7 +6141,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.openRouteTable": {
 		en: "Open route table",
-		ar: "Open route table", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح جدول المسارات",
 		es: "Abrir tabla de rutas",
 		fr: "Ouvrir la table de routes",
 		de: "Routentabelle öffnen",
@@ -6153,7 +6153,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.savedSuccess": {
 		en: "Route page saved successfully.",
-		ar: "Route page saved successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حفظ صفحة المسار بنجاح.",
 		es: "Página de ruta guardada con éxito.",
 		fr: "Page de route enregistrée avec succès.",
 		de: "Routenseite erfolgreich gespeichert.",
@@ -6165,7 +6165,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.general": {
 		en: "General",
-		ar: "General", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عام",
 		es: "General",
 		fr: "Général",
 		de: "Allgemein",
@@ -6177,7 +6177,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.generalDesc": {
 		en: "Public route identity, summary copy, and metadata defaults for this structured page.",
-		ar: "Public route identity, summary copy, and metadata defaults for this structured page.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هوية المسار العام، والنص الموجز، والبيانات الوصفية الافتراضية لهذه الصفحة المنظَّمة.",
 		es: "Identidad pública de la ruta, copia de resumen y metadatos predeterminados para esta página estructurada.",
 		fr: "Identité publique de la route, texte de résumé et métadonnées par défaut pour cette page structurée.",
 		de: "Öffentliche Routenidentität, Zusammenfassungstext und Metadaten-Standardwerte für diese strukturierte Seite.",
@@ -6189,7 +6189,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.publicRoute": {
 		en: "Public route:",
-		ar: "Public route:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسار العام:",
 		es: "Ruta pública:",
 		fr: "Route publique :",
 		de: "Öffentliche Route:",
@@ -6201,7 +6201,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.templateLabel": {
 		en: "Template:",
-		ar: "Template:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قالب:",
 		es: "Plantilla:",
 		fr: "Modèle :",
 		de: "Vorlage:",
@@ -6213,7 +6213,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.titleField": {
 		en: "Title",
-		ar: "Title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العنوان",
 		es: "Título",
 		fr: "Titre",
 		de: "Titel",
@@ -6225,7 +6225,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.titleFieldAria": {
 		en: "Route page title",
-		ar: "Route page title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عنوان صفحة المسار",
 		es: "Título de la página de ruta",
 		fr: "Titre de la page de route",
 		de: "Titel der Routenseite",
@@ -6237,7 +6237,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.summary": {
 		en: "Summary",
-		ar: "Summary", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الملخّص",
 		es: "Resumen",
 		fr: "Résumé",
 		de: "Zusammenfassung",
@@ -6249,7 +6249,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.summaryAria": {
 		en: "Route page summary",
-		ar: "Route page summary", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملخّص صفحة المسار",
 		es: "Resumen de la página de ruta",
 		fr: "Résumé de la page de route",
 		de: "Zusammenfassung der Routenseite",
@@ -6261,7 +6261,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.canonicalUrl": {
 		en: "Canonical URL",
-		ar: "Canonical URL", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الرابط الأساسي",
 		es: "URL canónica",
 		fr: "URL canonique",
 		de: "Kanonische URL",
@@ -6273,7 +6273,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.robots": {
 		en: "Robots",
-		ar: "Robots", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "Robots",
 		es: "Robots",
 		fr: "Robots",
 		de: "Robots",
@@ -6285,7 +6285,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.robotsAria": {
 		en: "Robots directive",
-		ar: "Robots directive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "توجيه Robots",
 		es: "Directiva de robots",
 		fr: "Directive robots",
 		de: "Robots-Direktive",
@@ -6297,7 +6297,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.ogImage": {
 		en: "OG Image",
-		ar: "OG Image", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صورة OG",
 		es: "Imagen OG",
 		fr: "Image OG",
 		de: "OG-Bild",
@@ -6309,7 +6309,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.ogImageAria": {
 		en: "OG image",
-		ar: "OG image", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صورة OG",
 		es: "Imagen OG",
 		fr: "Image OG",
 		de: "OG-Bild",
@@ -6321,7 +6321,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.ownerLocale": {
 		en: "Owner & Locale",
-		ar: "Owner & Locale", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المالك واللغة",
 		es: "Propietario y configuración regional",
 		fr: "Propriétaire et locale",
 		de: "Eigentümer & Sprache",
@@ -6333,7 +6333,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.ownerLocaleDesc": {
 		en: "Jump back to the main owner editor or switch to the linked locale record from here.",
-		ar: "Jump back to the main owner editor or switch to the linked locale record from here.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ارجع إلى محرّر المالك الرئيسي أو بدِّل إلى سجل اللغة المرتبط من هنا.",
 		es: "Vuelve al editor principal del propietario o cambia al registro de la configuración regional vinculada desde aquí.",
 		fr: "Revenez à l'éditeur propriétaire principal ou passez à l'enregistrement de la locale liée depuis ici.",
 		de: "Springen Sie zurück zum Hauptbesitzer-Editor oder wechseln Sie hier zum verknüpften Sprachdatensatz.",
@@ -6345,7 +6345,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.belongsToPagesWorkflow": {
 		en: "This technical route record belongs to the main Pages workflow.",
-		ar: "This technical route record belongs to the main Pages workflow.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'ينتمي سجل المسار الفني هذا إلى سير عمل "الصفحات" الرئيسي.',
 		es: "Este registro técnico de ruta pertenece al flujo de trabajo principal de Páginas.",
 		fr: "Cet enregistrement technique de route appartient au flux de travail principal Pages.",
 		de: "Dieser technische Routendatensatz gehört zum Haupt-Workflow von Seiten.",
@@ -6357,7 +6357,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.openPagesIndex": {
 		en: "Open Pages index",
-		ar: "Open Pages index", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح فهرس الصفحات",
 		es: "Abrir índice de páginas",
 		fr: "Ouvrir l'index des pages",
 		de: "Seitenindex öffnen",
@@ -6369,7 +6369,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.openPublicRoute": {
 		en: "Open public route",
-		ar: "Open public route", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح المسار العام",
 		es: "Abrir ruta pública",
 		fr: "Ouvrir la route publique",
 		de: "Öffentliche Route öffnen",
@@ -6381,7 +6381,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.editEnglishOwner": {
 		en: "Edit English owner",
-		ar: "Edit English owner", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل المالك الإنجليزي",
 		es: "Editar propietario en inglés",
 		fr: "Modifier le propriétaire anglais",
 		de: "Englischen Eigentümer bearbeiten",
@@ -6393,7 +6393,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.editEnglishVariant": {
 		en: "Edit English variant",
-		ar: "Edit English variant", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل النسخة الإنجليزية",
 		es: "Editar variante en inglés",
 		fr: "Modifier la variante anglaise",
 		de: "Englische Variante bearbeiten",
@@ -6405,7 +6405,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.editSpanishVariant": {
 		en: "Edit Spanish variant",
-		ar: "Edit Spanish variant", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل النسخة الإسبانية",
 		es: "Editar variante en español",
 		fr: "Modifier la variante espagnole",
 		de: "Spanische Variante bearbeiten",
@@ -6417,7 +6417,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.translationState": {
 		en: "Translation state",
-		ar: "Translation state", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حالة الترجمة",
 		es: "Estado de traducción",
 		fr: "État de traduction",
 		de: "Übersetzungsstatus",
@@ -6429,7 +6429,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.stateNotStarted": {
 		en: "Not started",
-		ar: "Not started", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لم يبدأ",
 		es: "No iniciado",
 		fr: "Non commencé",
 		de: "Nicht begonnen",
@@ -6441,7 +6441,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.statePartial": {
 		en: "Partial",
-		ar: "Partial", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جزئي",
 		es: "Parcial",
 		fr: "Partiel",
 		de: "Teilweise",
@@ -6453,7 +6453,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.stateFallbackEn": {
 		en: "Fallback to English",
-		ar: "Fallback to English", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الرجوع إلى الإنجليزية",
 		es: "Recurrir al inglés",
 		fr: "Revenir à l'anglais",
 		de: "Rückfall auf Englisch",
@@ -6465,7 +6465,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.stateTranslated": {
 		en: "Translated",
-		ar: "Translated", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مترجَم",
 		es: "Traducido",
 		fr: "Traduit",
 		de: "Übersetzt",
@@ -6477,7 +6477,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.stateReviewed": {
 		en: "Reviewed",
-		ar: "Reviewed", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تمت المراجعة",
 		es: "Revisado",
 		fr: "Révisé",
 		de: "Überprüft",
@@ -6489,7 +6489,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.statePublished": {
 		en: "Published",
-		ar: "Published", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منشور",
 		es: "Publicado",
 		fr: "Publié",
 		de: "Veröffentlicht",
@@ -6501,7 +6501,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.updateTranslationState": {
 		en: "Update translation state",
-		ar: "Update translation state", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحديث حالة الترجمة",
 		es: "Actualizar estado de traducción",
 		fr: "Mettre à jour l'état de traduction",
 		de: "Übersetzungsstatus aktualisieren",
@@ -6513,7 +6513,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.seoHeading": {
 		en: "SEO",
-		ar: "SEO", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحسين محركات البحث",
 		es: "SEO",
 		fr: "SEO",
 		de: "SEO",
@@ -6525,7 +6525,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.seoDesc": {
 		en: "Search-facing title and description for the route-backed page.",
-		ar: "Search-facing title and description for the route-backed page.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العنوان والوصف الموجَّهان للبحث للصفحة المستندة إلى مسار.",
 		es: "Título y descripción orientados a buscadores para la página con ruta.",
 		fr: "Titre et description orientés recherche pour la page basée sur la route.",
 		de: "Such-orientierter Titel und Beschreibung für die routenbasierte Seite.",
@@ -6537,7 +6537,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.seoTitle": {
 		en: "SEO Title",
-		ar: "SEO Title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عنوان SEO",
 		es: "Título SEO",
 		fr: "Titre SEO",
 		de: "SEO-Titel",
@@ -6549,7 +6549,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.seoTitleAria": {
 		en: "SEO title",
-		ar: "SEO title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عنوان SEO",
 		es: "Título SEO",
 		fr: "Titre SEO",
 		de: "SEO-Titel",
@@ -6561,7 +6561,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.metaDescription": {
 		en: "Meta Description",
-		ar: "Meta Description", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وصف ميتا",
 		es: "Meta descripción",
 		fr: "Méta-description",
 		de: "Meta-Beschreibung",
@@ -6573,7 +6573,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.metaDescriptionAria": {
 		en: "Meta description",
-		ar: "Meta description", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وصف ميتا",
 		es: "Meta descripción",
 		fr: "Méta-description",
 		de: "Meta-Beschreibung",
@@ -6585,7 +6585,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.alternateLinks": {
 		en: "Alternate Links",
-		ar: "Alternate Links", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "روابط بديلة",
 		es: "Enlaces alternativos",
 		fr: "Liens alternatifs",
 		de: "Alternative Links",
@@ -6597,7 +6597,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.alternateLinksDesc": {
 		en: "Hreflang mapping for linked English and Spanish route variants.",
-		ar: "Hreflang mapping for linked English and Spanish route variants.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعيين hreflang لنسخ المسار الإنجليزية والإسبانية المرتبطة.",
 		es: "Asignación hreflang para las variantes de ruta vinculadas en inglés y español.",
 		fr: "Mappage hreflang pour les variantes de route anglaise et espagnole liées.",
 		de: "Hreflang-Zuordnung für verknüpfte englische und spanische Routenvarianten.",
@@ -6609,7 +6609,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.alternateLinksJsonAria": {
 		en: "Alternate links JSON",
-		ar: "Alternate links JSON", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "روابط بديلة بصيغة JSON",
 		es: "JSON de enlaces alternativos",
 		fr: "JSON des liens alternatifs",
 		de: "Alternative Links JSON",
@@ -6621,7 +6621,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.sectionsJson": {
 		en: "Sections JSON",
-		ar: "Sections JSON", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أقسام JSON",
 		es: "JSON de secciones",
 		fr: "JSON des sections",
 		de: "Abschnitts-JSON",
@@ -6633,7 +6633,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.sectionsJsonDesc": {
 		en: "Structured section payload for the marketing page renderer.",
-		ar: "Structured section payload for the marketing page renderer.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حمولة قسم منظَّم لعارض صفحة التسويق.",
 		es: "Carga útil de sección estructurada para el renderizador de la página de marketing.",
 		fr: "Charge utile de section structurée pour le rendu de la page marketing.",
 		de: "Strukturierte Abschnittsdaten für den Marketing-Seitenrenderer.",
@@ -6645,7 +6645,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.sectionsJsonNote": {
 		en: "This slice uses structured JSON editing for registry-backed marketing pages.",
-		ar: "This slice uses structured JSON editing for registry-backed marketing pages.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تستخدم هذه الشريحة تحرير JSON المنظَّم لصفحات التسويق المستندة إلى السجل.",
 		es: "Este sector utiliza edición JSON estructurada para páginas de marketing basadas en el registro.",
 		fr: "Cette section utilise l'édition JSON structurée pour les pages marketing basées sur le registre.",
 		de: "Dieser Bereich verwendet strukturierte JSON-Bearbeitung für registry-gestützte Marketingseiten.",
@@ -6657,7 +6657,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.sectionsJsonAria": {
 		en: "Sections JSON",
-		ar: "Sections JSON", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أقسام JSON",
 		es: "JSON de secciones",
 		fr: "JSON des sections",
 		de: "Abschnitts-JSON",
@@ -6669,7 +6669,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.revisionNote": {
 		en: "Revision Note",
-		ar: "Revision Note", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملاحظة المراجعة",
 		es: "Nota de revisión",
 		fr: "Note de révision",
 		de: "Revisionsnotiz",
@@ -6681,7 +6681,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.revisionNoteDesc": {
 		en: "Summarize the change so the route revision history stays understandable.",
-		ar: "Summarize the change so the route revision history stays understandable.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لخّص التغيير ليبقى سجل مراجعات المسار مفهومًا.",
 		es: "Resume el cambio para que el historial de revisiones de la ruta siga siendo comprensible.",
 		fr: "Résumez la modification pour que l'historique des révisions de route reste compréhensible.",
 		de: "Fassen Sie die Änderung zusammen, damit die Routenrevisionshistorie verständlich bleibt.",
@@ -6693,7 +6693,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.revisionNoteAria": {
 		en: "Revision note",
-		ar: "Revision note", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملاحظة المراجعة",
 		es: "Nota de revisión",
 		fr: "Note de révision",
 		de: "Revisionsnotiz",
@@ -6705,7 +6705,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.revisionNotePlaceholder": {
 		en: "Summarize this change",
-		ar: "Summarize this change", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لخّص هذا التغيير",
 		es: "Resume este cambio",
 		fr: "Résumez ce changement",
 		de: "Fassen Sie diese Änderung zusammen",
@@ -6717,7 +6717,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.saveRoutePage": {
 		en: "Save route page",
-		ar: "Save route page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ صفحة المسار",
 		es: "Guardar página de ruta",
 		fr: "Enregistrer la page de route",
 		de: "Routenseite speichern",
@@ -6729,7 +6729,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.backToRouteTable": {
 		en: "Back to route table",
-		ar: "Back to route table", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العودة إلى جدول المسارات",
 		es: "Volver a la tabla de rutas",
 		fr: "Retour à la table de routes",
 		de: "Zurück zur Routentabelle",
@@ -6741,7 +6741,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.notFoundTitle": {
 		en: "Not Found",
-		ar: "Not Found", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "غير موجود",
 		es: "No encontrado",
 		fr: "Introuvable",
 		de: "Nicht gefunden",
@@ -6753,7 +6753,7 @@ export const pageLabels = {
 	},
 	"routePageEditor.notFoundDesc": {
 		en: "The requested route page could not be found.",
-		ar: "The requested route page could not be found.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعذّر العثور على صفحة المسار المطلوبة.",
 		es: "No se pudo encontrar la página de ruta solicitada.",
 		fr: "La page de route demandée est introuvable.",
 		de: "Die angeforderte Routenseite wurde nicht gefunden.",
@@ -6765,7 +6765,7 @@ export const pageLabels = {
 	},
 	"archives.title": {
 		en: "Archives",
-		ar: "Archives", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الأرشيفات",
 		es: "Archivos",
 		fr: "Archives",
 		de: "Archive",
@@ -6777,7 +6777,7 @@ export const pageLabels = {
 	},
 	"archives.description": {
 		en: "Owner-editable metadata for public archive landing pages.",
-		ar: "Owner-editable metadata for public archive landing pages.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بيانات وصفية قابلة للتحرير من المالك لصفحات هبوط الأرشيف العامة.",
 		es: "Metadatos editables por el propietario para páginas públicas de aterrizaje de archivos.",
 		fr: "Métadonnées modifiables par le propriétaire pour les pages d'atterrissage publiques d'archives.",
 		de: "Vom Eigentümer editierbare Metadaten für öffentliche Archiv-Landingpages.",
@@ -6789,7 +6789,7 @@ export const pageLabels = {
 	},
 	"archives.partialResults": {
 		en: "Some archive metadata is temporarily unavailable. This page is showing partial results.",
-		ar: "Some archive metadata is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات الأرشيف الوصفية غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos metadatos de archivo no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines métadonnées d'archive sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Archiv-Metadaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -6801,7 +6801,7 @@ export const pageLabels = {
 	},
 	"archives.backToPages": {
 		en: "Back to pages",
-		ar: "Back to pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العودة إلى الصفحات",
 		es: "Volver a páginas",
 		fr: "Retour aux pages",
 		de: "Zurück zu Seiten",
@@ -6813,7 +6813,7 @@ export const pageLabels = {
 	},
 	"archives.managePosts": {
 		en: "Manage posts in archive families",
-		ar: "Manage posts in archive families", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر المنشورات في عائلات الأرشيف",
 		es: "Gestionar publicaciones en familias de archivos",
 		fr: "Gérer les publications dans les familles d'archives",
 		de: "Beiträge in Archivfamilien verwalten",
@@ -6825,7 +6825,7 @@ export const pageLabels = {
 	},
 	"archives.totalArchives": {
 		en: "Total Archives",
-		ar: "Total Archives", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجمالي الأرشيفات",
 		es: "Archivos totales",
 		fr: "Total d'archives",
 		de: "Gesamtarchive",
@@ -6837,7 +6837,7 @@ export const pageLabels = {
 	},
 	"archives.totalListingItems": {
 		en: "Total Listing Items",
-		ar: "Total Listing Items", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجمالي عناصر القائمة",
 		es: "Total de elementos del listado",
 		fr: "Total des éléments de la liste",
 		de: "Gesamtlistenelemente",
@@ -6849,7 +6849,7 @@ export const pageLabels = {
 	},
 	"archives.archivesByKind": {
 		en: "Archives by Kind",
-		ar: "Archives by Kind", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الأرشيفات حسب النوع",
 		es: "Archivos por tipo",
 		fr: "Archives par type",
 		de: "Archive nach Art",
@@ -6861,7 +6861,7 @@ export const pageLabels = {
 	},
 	"archives.archivesByKindDesc": {
 		en: "Each archive kind has its own owner-edited landing pages.",
-		ar: "Each archive kind has its own owner-edited landing pages.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لكل نوع أرشيف صفحات هبوط خاصة به يحرّرها المالك.",
 		es: "Cada tipo de archivo tiene sus propias páginas de aterrizaje editadas por el propietario.",
 		fr: "Chaque type d'archive possède ses propres pages d'atterrissage modifiées par le propriétaire.",
 		de: "Jede Archivart hat eigene, vom Eigentümer bearbeitete Landingpages.",
@@ -6873,7 +6873,7 @@ export const pageLabels = {
 	},
 	"archives.allArchives": {
 		en: "All Archives",
-		ar: "All Archives", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل الأرشيفات",
 		es: "Todos los archivos",
 		fr: "Toutes les archives",
 		de: "Alle Archive",
@@ -6885,7 +6885,7 @@ export const pageLabels = {
 	},
 	"archives.allArchivesDesc": {
 		en: "Edit archive metadata here. Use Posts for the entries that appear inside each archive.",
-		ar: "Edit archive metadata here. Use Posts for the entries that appear inside each archive.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'حرِّر بيانات الأرشيف الوصفية هنا. استخدم "المنشورات" للمدخلات التي تظهر داخل كل أرشيف.',
 		es: "Edita los metadatos de archivo aquí. Usa Publicaciones para las entradas que aparecen dentro de cada archivo.",
 		fr: "Modifiez ici les métadonnées d'archive. Utilisez Publications pour les entrées qui apparaissent dans chaque archive.",
 		de: "Bearbeiten Sie hier die Archiv-Metadaten. Verwenden Sie Beiträge für die Einträge in jedem Archiv.",
@@ -6897,7 +6897,7 @@ export const pageLabels = {
 	},
 	"archives.kind": {
 		en: "Kind",
-		ar: "Kind", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النوع",
 		es: "Tipo",
 		fr: "Type",
 		de: "Art",
@@ -6909,7 +6909,7 @@ export const pageLabels = {
 	},
 	"archives.slug": {
 		en: "Slug",
-		ar: "Slug", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المعرّف اللطيف",
 		es: "Slug",
 		fr: "Slug",
 		de: "Slug",
@@ -6921,7 +6921,7 @@ export const pageLabels = {
 	},
 	"archives.items": {
 		en: "Items",
-		ar: "Items", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العناصر",
 		es: "Elementos",
 		fr: "Éléments",
 		de: "Elemente",
@@ -6933,7 +6933,7 @@ export const pageLabels = {
 	},
 	"archives.editArchive": {
 		en: "Edit archive",
-		ar: "Edit archive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل الأرشيف",
 		es: "Editar archivo",
 		fr: "Modifier l'archive",
 		de: "Archiv bearbeiten",
@@ -6945,7 +6945,7 @@ export const pageLabels = {
 	},
 	"archives.openArchive": {
 		en: "Open archive",
-		ar: "Open archive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح الأرشيف",
 		es: "Abrir archivo",
 		fr: "Ouvrir l'archive",
 		de: "Archiv öffnen",
@@ -6957,7 +6957,7 @@ export const pageLabels = {
 	},
 	"archives.noteStrong": {
 		en: "Note:",
-		ar: "Note:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملاحظة:",
 		es: "Nota:",
 		fr: "Remarque :",
 		de: "Hinweis:",
@@ -6969,7 +6969,7 @@ export const pageLabels = {
 	},
 	"archives.noteBody": {
 		en: "Archive metadata is edited here. Use the archive editor for public titles and SEO, and use Posts to manage the individual content that appears inside each archive.",
-		ar: "Archive metadata is edited here. Use the archive editor for public titles and SEO, and use Posts to manage the individual content that appears inside each archive.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'تُحرَّر بيانات الأرشيف الوصفية هنا. استخدِم محرّر الأرشيف للعناوين العامة وتحسين محركات البحث، واستخدم "المنشورات" لإدارة المحتوى الذي يظهر داخل كل أرشيف.',
 		es: "Los metadatos de archivo se editan aquí. Usa el editor de archivos para títulos públicos y SEO, y usa Publicaciones para gestionar el contenido individual que aparece dentro de cada archivo.",
 		fr: "Les métadonnées d'archive sont modifiées ici. Utilisez l'éditeur d'archive pour les titres publics et le SEO, et utilisez Publications pour gérer le contenu individuel qui apparaît dans chaque archive.",
 		de: "Archiv-Metadaten werden hier bearbeitet. Verwenden Sie den Archiv-Editor für öffentliche Titel und SEO und Beiträge, um die einzelnen Inhalte in jedem Archiv zu verwalten.",
@@ -6981,7 +6981,7 @@ export const pageLabels = {
 	},
 	"archives.forbiddenTitle": {
 		en: "Forbidden",
-		ar: "Forbidden", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ممنوع",
 		es: "Prohibido",
 		fr: "Interdit",
 		de: "Verboten",
@@ -6993,7 +6993,7 @@ export const pageLabels = {
 	},
 	"archives.forbiddenDesc": {
 		en: "This action requires an admin account.",
-		ar: "This action requires an admin account.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول.",
 		es: "Esta acción requiere una cuenta de administración.",
 		fr: "Cette action nécessite un compte administrateur.",
 		de: "Diese Aktion erfordert ein Admin-Konto.",
@@ -7005,7 +7005,7 @@ export const pageLabels = {
 	},
 	"archives.forbiddenBody": {
 		en: "This action requires an admin account and is hidden from editor-only roles.",
-		ar: "This action requires an admin account and is hidden from editor-only roles.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول وهو مخفي عن الأدوار المحرّرة فقط.",
 		es: "Esta acción requiere una cuenta de administración y está oculta para roles solo de editor.",
 		fr: "Cette action nécessite un compte administrateur et est masquée pour les rôles éditeur uniquement.",
 		de: "Diese Aktion erfordert ein Admin-Konto und ist für reine Editor-Rollen ausgeblendet.",
@@ -7017,7 +7017,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.title": {
 		en: "Edit Archive",
-		ar: "Edit Archive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل الأرشيف",
 		es: "Editar archivo",
 		fr: "Modifier l'archive",
 		de: "Archiv bearbeiten",
@@ -7029,7 +7029,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.description": {
 		en: "Editable metadata for public archive routes. Use Posts to manage the content that appears inside the archive.",
-		ar: "Editable metadata for public archive routes. Use Posts to manage the content that appears inside the archive.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'بيانات وصفية قابلة للتحرير لمسارات الأرشيف العامة. استخدِم "المنشورات" لإدارة المحتوى داخل الأرشيف.',
 		es: "Metadatos editables para rutas públicas de archivo. Usa Publicaciones para gestionar el contenido que aparece dentro del archivo.",
 		fr: "Métadonnées modifiables pour les routes d'archives publiques. Utilisez Publications pour gérer le contenu qui apparaît dans l'archive.",
 		de: "Editierbare Metadaten für öffentliche Archivrouten. Verwenden Sie Beiträge, um die im Archiv erscheinenden Inhalte zu verwalten.",
@@ -7041,7 +7041,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.breadcrumb": {
 		en: "breadcrumb",
-		ar: "breadcrumb", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسار التنقل",
 		es: "ruta de navegación",
 		fr: "fil d'Ariane",
 		de: "Brotkrumen",
@@ -7053,7 +7053,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.archivesLink": {
 		en: "Archives",
-		ar: "Archives", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الأرشيفات",
 		es: "Archivos",
 		fr: "Archives",
 		de: "Archive",
@@ -7065,7 +7065,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.partialResults": {
 		en: "Some archive data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some archive data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات الأرشيف غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos del archivo no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données d'archive sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Archivdaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -7077,7 +7077,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.backToArchives": {
 		en: "Back to archives",
-		ar: "Back to archives", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العودة إلى الأرشيفات",
 		es: "Volver a archivos",
 		fr: "Retour aux archives",
 		de: "Zurück zu Archiven",
@@ -7089,7 +7089,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.openPublicArchive": {
 		en: "Open public archive",
-		ar: "Open public archive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح الأرشيف العام",
 		es: "Abrir archivo público",
 		fr: "Ouvrir l'archive publique",
 		de: "Öffentliches Archiv öffnen",
@@ -7101,7 +7101,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.manageInPosts": {
 		en: "Manage archive content in posts",
-		ar: "Manage archive content in posts", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر محتوى الأرشيف في المنشورات",
 		es: "Gestionar el contenido del archivo en publicaciones",
 		fr: "Gérer le contenu de l'archive dans les publications",
 		de: "Archivinhalte in Beiträgen verwalten",
@@ -7113,7 +7113,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.savedSuccess": {
 		en: "Archive route updated successfully.",
-		ar: "Archive route updated successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تحديث مسار الأرشيف بنجاح.",
 		es: "Ruta de archivo actualizada con éxito.",
 		fr: "Route d'archive mise à jour avec succès.",
 		de: "Archivroute erfolgreich aktualisiert.",
@@ -7125,7 +7125,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.metadataHeading": {
 		en: "Archive Metadata",
-		ar: "Archive Metadata", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بيانات الأرشيف الوصفية",
 		es: "Metadatos del archivo",
 		fr: "Métadonnées d'archive",
 		de: "Archiv-Metadaten",
@@ -7137,7 +7137,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.publicArchiveRoute": {
 		en: "Public archive route:",
-		ar: "Public archive route:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسار الأرشيف العام:",
 		es: "Ruta pública del archivo:",
 		fr: "Route publique de l'archive :",
 		de: "Öffentliche Archivroute:",
@@ -7149,7 +7149,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.titleField": {
 		en: "Title",
-		ar: "Title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العنوان",
 		es: "Título",
 		fr: "Titre",
 		de: "Titel",
@@ -7161,7 +7161,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.summary": {
 		en: "Summary",
-		ar: "Summary", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الملخّص",
 		es: "Resumen",
 		fr: "Résumé",
 		de: "Zusammenfassung",
@@ -7173,7 +7173,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.seoTitle": {
 		en: "SEO Title",
-		ar: "SEO Title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عنوان SEO",
 		es: "Título SEO",
 		fr: "Titre SEO",
 		de: "SEO-Titel",
@@ -7185,7 +7185,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.metaDescription": {
 		en: "Meta Description",
-		ar: "Meta Description", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وصف ميتا",
 		es: "Meta descripción",
 		fr: "Méta-description",
 		de: "Meta-Beschreibung",
@@ -7197,7 +7197,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.canonicalUrlOverride": {
 		en: "Canonical URL Override",
-		ar: "Canonical URL Override", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تجاوز الرابط الأساسي",
 		es: "Anulación de URL canónica",
 		fr: "Remplacement de l'URL canonique",
 		de: "Kanonische URL überschreiben",
@@ -7209,7 +7209,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.robotsDirective": {
 		en: "Robots Directive",
-		ar: "Robots Directive", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "توجيه Robots",
 		es: "Directiva de robots",
 		fr: "Directive robots",
 		de: "Robots-Direktive",
@@ -7221,7 +7221,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.revisionNote": {
 		en: "Revision Note",
-		ar: "Revision Note", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملاحظة المراجعة",
 		es: "Nota de revisión",
 		fr: "Note de révision",
 		de: "Revisionsnotiz",
@@ -7233,7 +7233,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.revisionNotePlaceholder": {
 		en: "Summarize this change",
-		ar: "Summarize this change", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لخّص هذا التغيير",
 		es: "Resume este cambio",
 		fr: "Résumez ce changement",
 		de: "Fassen Sie diese Änderung zusammen",
@@ -7245,7 +7245,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.saveArchive": {
 		en: "Save archive metadata",
-		ar: "Save archive metadata", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ بيانات الأرشيف الوصفية",
 		es: "Guardar metadatos del archivo",
 		fr: "Enregistrer les métadonnées d'archive",
 		de: "Archiv-Metadaten speichern",
@@ -7257,7 +7257,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -7269,7 +7269,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.notFoundTitle": {
 		en: "Not Found",
-		ar: "Not Found", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "غير موجود",
 		es: "No encontrado",
 		fr: "Introuvable",
 		de: "Nicht gefunden",
@@ -7281,7 +7281,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.notFoundDesc": {
 		en: "The requested archive route could not be found.",
-		ar: "The requested archive route could not be found.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعذّر العثور على مسار الأرشيف المطلوب.",
 		es: "No se pudo encontrar la ruta de archivo solicitada.",
 		fr: "La route d'archive demandée est introuvable.",
 		de: "Die angeforderte Archivroute wurde nicht gefunden.",
@@ -7293,7 +7293,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.forbiddenTitle": {
 		en: "Forbidden",
-		ar: "Forbidden", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ممنوع",
 		es: "Prohibido",
 		fr: "Interdit",
 		de: "Verboten",
@@ -7305,7 +7305,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.forbiddenDesc": {
 		en: "This action requires an admin account.",
-		ar: "This action requires an admin account.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول.",
 		es: "Esta acción requiere una cuenta de administración.",
 		fr: "Cette action nécessite un compte administrateur.",
 		de: "Diese Aktion erfordert ein Admin-Konto.",
@@ -7317,7 +7317,7 @@ export const pageLabels = {
 	},
 	"archiveEditor.forbiddenBody": {
 		en: "This action requires an admin account and is hidden from editor-only roles.",
-		ar: "This action requires an admin account and is hidden from editor-only roles.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول وهو مخفي عن الأدوار المحرّرة فقط.",
 		es: "Esta acción requiere una cuenta de administración y está oculta para roles solo de editor.",
 		fr: "Cette action nécessite un compte administrateur et est masquée pour les rôles éditeur uniquement.",
 		de: "Diese Aktion erfordert ein Admin-Konto und ist für reine Editor-Rollen ausgeblendet.",
@@ -7329,7 +7329,7 @@ export const pageLabels = {
 	},
 	"translations.title": {
 		en: "Translations",
-		ar: "Translations", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الترجمات",
 		es: "Traducciones",
 		fr: "Traductions",
 		de: "Übersetzungen",
@@ -7341,7 +7341,7 @@ export const pageLabels = {
 	},
 	"translations.description": {
 		en: "Translation coverage and state. Edit content inside the owning page or route editor.",
-		ar: "Translation coverage and state. Edit content inside the owning page or route editor.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تغطية الترجمة وحالتها. حرِّر المحتوى داخل محرّر الصفحة أو المسار المالك.",
 		es: "Cobertura y estado de traducción. Edita el contenido dentro de la página propietaria o el editor de rutas.",
 		fr: "Couverture et état des traductions. Modifiez le contenu dans la page propriétaire ou l'éditeur de route.",
 		de: "Übersetzungsabdeckung und -status. Inhalte im Besitzer- oder Routen-Editor bearbeiten.",
@@ -7353,7 +7353,7 @@ export const pageLabels = {
 	},
 	"translations.partialResults": {
 		en: "Some translation records are temporarily unavailable. This page is showing partial results.",
-		ar: "Some translation records are temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض سجلات الترجمة غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos registros de traducción no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines entrées de traduction sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Übersetzungseinträge sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -7365,7 +7365,7 @@ export const pageLabels = {
 	},
 	"translations.savedSuccess": {
 		en: "Translation state updated successfully.",
-		ar: "Translation state updated successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تحديث حالة الترجمة بنجاح.",
 		es: "Estado de traducción actualizado con éxito.",
 		fr: "État de traduction mis à jour avec succès.",
 		de: "Übersetzungsstatus erfolgreich aktualisiert.",
@@ -7377,7 +7377,7 @@ export const pageLabels = {
 	},
 	"translations.localizedRoutes": {
 		en: "Localized routes",
-		ar: "Localized routes", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسارات المترجَمة",
 		es: "Rutas localizadas",
 		fr: "Routes localisées",
 		de: "Lokalisierte Routen",
@@ -7389,7 +7389,7 @@ export const pageLabels = {
 	},
 	"translations.localizedRoutesDesc": {
 		en: "Spanish routes currently tracked in translation coverage.",
-		ar: "Spanish routes currently tracked in translation coverage.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسارات الإسبانية المتعقَّبة حاليًا في تغطية الترجمة.",
 		es: "Rutas en español que se siguen actualmente en la cobertura de traducción.",
 		fr: "Routes espagnoles actuellement suivies dans la couverture de traduction.",
 		de: "Aktuell in der Übersetzungsabdeckung verfolgte spanische Routen.",
@@ -7401,7 +7401,7 @@ export const pageLabels = {
 	},
 	"translations.publishedTranslations": {
 		en: "Published translations",
-		ar: "Published translations", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الترجمات المنشورة",
 		es: "Traducciones publicadas",
 		fr: "Traductions publiées",
 		de: "Veröffentlichte Übersetzungen",
@@ -7413,7 +7413,7 @@ export const pageLabels = {
 	},
 	"translations.publishedTranslationsDesc": {
 		en: "Routes that are ready and publicly published in Spanish.",
-		ar: "Routes that are ready and publicly published in Spanish.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسارات الجاهزة والمنشورة علنًا بالإسبانية.",
 		es: "Rutas listas y publicadas públicamente en español.",
 		fr: "Routes prêtes et publiées publiquement en espagnol.",
 		de: "Routen, die bereit und öffentlich auf Spanisch veröffentlicht sind.",
@@ -7425,7 +7425,7 @@ export const pageLabels = {
 	},
 	"translations.coverageKicker": {
 		en: "Coverage",
-		ar: "Coverage", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التغطية",
 		es: "Cobertura",
 		fr: "Couverture",
 		de: "Abdeckung",
@@ -7437,7 +7437,7 @@ export const pageLabels = {
 	},
 	"translations.coverageHeading": {
 		en: "Translation Coverage",
-		ar: "Translation Coverage", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تغطية الترجمة",
 		es: "Cobertura de traducción",
 		fr: "Couverture de traduction",
 		de: "Übersetzungsabdeckung",
@@ -7449,7 +7449,7 @@ export const pageLabels = {
 	},
 	"translations.coverageDesc": {
 		en: "Use this screen to triage untranslated routes, then jump into the owning editor to make content changes.",
-		ar: "Use this screen to triage untranslated routes, then jump into the owning editor to make content changes.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استخدِم هذه الشاشة لفرز المسارات غير المترجَمة، ثم انتقل إلى المحرّر المالك لإجراء تغييرات المحتوى.",
 		es: "Usa esta pantalla para clasificar las rutas sin traducir y luego salta al editor propietario para hacer cambios de contenido.",
 		fr: "Utilisez cet écran pour trier les routes non traduites, puis accédez à l'éditeur propriétaire pour modifier le contenu.",
 		de: "Nutzen Sie diesen Bildschirm, um nicht übersetzte Routen zu sichten, und springen Sie dann in den Besitzer-Editor, um Inhalte zu ändern.",
@@ -7461,7 +7461,7 @@ export const pageLabels = {
 	},
 	"translations.filterAria": {
 		en: "Filter translations by state",
-		ar: "Filter translations by state", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تصفية الترجمات حسب الحالة",
 		es: "Filtrar traducciones por estado",
 		fr: "Filtrer les traductions par état",
 		de: "Übersetzungen nach Status filtern",
@@ -7473,7 +7473,7 @@ export const pageLabels = {
 	},
 	"translations.allStates": {
 		en: "All states",
-		ar: "All states", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل الحالات",
 		es: "Todos los estados",
 		fr: "Tous les états",
 		de: "Alle Status",
@@ -7485,7 +7485,7 @@ export const pageLabels = {
 	},
 	"translations.applyFilter": {
 		en: "Apply filter",
-		ar: "Apply filter", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تطبيق المرشِّح",
 		es: "Aplicar filtro",
 		fr: "Appliquer le filtre",
 		de: "Filter anwenden",
@@ -7497,7 +7497,7 @@ export const pageLabels = {
 	},
 	"translations.summaryOf": {
 		en: "of",
-		ar: "of", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "من",
 		es: "de",
 		fr: "sur",
 		de: "von",
@@ -7509,7 +7509,7 @@ export const pageLabels = {
 	},
 	"translations.summaryRoutes": {
 		en: "localized routes",
-		ar: "localized routes", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسارات مترجَمة",
 		es: "rutas localizadas",
 		fr: "routes localisées",
 		de: "lokalisierte Routen",
@@ -7521,7 +7521,7 @@ export const pageLabels = {
 	},
 	"translations.tableAria": {
 		en: "Translation coverage",
-		ar: "Translation coverage", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تغطية الترجمة",
 		es: "Cobertura de traducción",
 		fr: "Couverture de traduction",
 		de: "Übersetzungsabdeckung",
@@ -7533,7 +7533,7 @@ export const pageLabels = {
 	},
 	"translations.route": {
 		en: "Route",
-		ar: "Route", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسار",
 		es: "Ruta",
 		fr: "Route",
 		de: "Route",
@@ -7545,7 +7545,7 @@ export const pageLabels = {
 	},
 	"translations.locale": {
 		en: "Locale",
-		ar: "Locale", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اللغة",
 		es: "Configuración regional",
 		fr: "Locale",
 		de: "Sprache",
@@ -7557,7 +7557,7 @@ export const pageLabels = {
 	},
 	"translations.englishSource": {
 		en: "English source",
-		ar: "English source", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المصدر الإنجليزي",
 		es: "Fuente en inglés",
 		fr: "Source anglaise",
 		de: "Englische Quelle",
@@ -7569,7 +7569,7 @@ export const pageLabels = {
 	},
 	"translations.edit": {
 		en: "Edit",
-		ar: "Edit", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل",
 		es: "Editar",
 		fr: "Modifier",
 		de: "Bearbeiten",
@@ -7581,7 +7581,7 @@ export const pageLabels = {
 	},
 	"translations.update": {
 		en: "Update",
-		ar: "Update", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحديث",
 		es: "Actualizar",
 		fr: "Mettre à jour",
 		de: "Aktualisieren",
@@ -7593,7 +7593,7 @@ export const pageLabels = {
 	},
 	"translations.editEn": {
 		en: "Edit EN",
-		ar: "Edit EN", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل الإنجليزية",
 		es: "Editar EN",
 		fr: "Modifier EN",
 		de: "EN bearbeiten",
@@ -7605,7 +7605,7 @@ export const pageLabels = {
 	},
 	"translations.editLocale": {
 		en: "Edit locale",
-		ar: "Edit locale", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل اللغة",
 		es: "Editar idioma",
 		fr: "Modifier la locale",
 		de: "Sprache bearbeiten",
@@ -7617,7 +7617,7 @@ export const pageLabels = {
 	},
 	"translations.translationStateForRoute": {
 		en: "Translation state for",
-		ar: "Translation state for", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حالة الترجمة لـ",
 		es: "Estado de traducción para",
 		fr: "État de traduction pour",
 		de: "Übersetzungsstatus für",
@@ -7629,7 +7629,7 @@ export const pageLabels = {
 	},
 	"translations.saveState": {
 		en: "Save state",
-		ar: "Save state", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ الحالة",
 		es: "Guardar estado",
 		fr: "Enregistrer l'état",
 		de: "Status speichern",
@@ -7641,7 +7641,7 @@ export const pageLabels = {
 	},
 	"translations.forbiddenTitle": {
 		en: "Forbidden",
-		ar: "Forbidden", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ممنوع",
 		es: "Prohibido",
 		fr: "Interdit",
 		de: "Verboten",
@@ -7653,7 +7653,7 @@ export const pageLabels = {
 	},
 	"translations.forbiddenDesc": {
 		en: "This action requires an admin account.",
-		ar: "This action requires an admin account.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول.",
 		es: "Esta acción requiere una cuenta de administración.",
 		fr: "Cette action nécessite un compte administrateur.",
 		de: "Diese Aktion erfordert ein Admin-Konto.",
@@ -7665,7 +7665,7 @@ export const pageLabels = {
 	},
 	"translations.forbiddenBody": {
 		en: "This action requires an admin account and is hidden from editor-only roles.",
-		ar: "This action requires an admin account and is hidden from editor-only roles.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول وهو مخفي عن الأدوار المحرّرة فقط.",
 		es: "Esta acción requiere una cuenta de administración y está oculta para roles solo de editor.",
 		fr: "Cette action nécessite un compte administrateur et est masquée pour les rôles éditeur uniquement.",
 		de: "Diese Aktion erfordert ein Admin-Konto und ist für reine Editor-Rollen ausgeblendet.",
@@ -7678,7 +7678,7 @@ export const pageLabels = {
 	// ANCHOR-BATCH-D: seo + system + api-tokens + webhooks
 	"seo.title": {
 		en: "SEO",
-		ar: "SEO", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحسين محركات البحث",
 		es: "SEO",
 		fr: "SEO",
 		de: "SEO",
@@ -7690,7 +7690,7 @@ export const pageLabels = {
 	},
 	"seo.description": {
 		en: "Review SEO metadata across pages, posts, archives, and system routes.",
-		ar: "Review SEO metadata across pages, posts, archives, and system routes.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "راجع بيانات SEO الوصفية عبر الصفحات والمنشورات والأرشيفات ومسارات النظام.",
 		es: "Revisa los metadatos de SEO en páginas, publicaciones, archivos y rutas del sistema.",
 		fr: "Examinez les métadonnées SEO sur les pages, articles, archives et routes système.",
 		de: "Prüfen Sie SEO-Metadaten für Seiten, Beiträge, Archive und Systemrouten.",
@@ -7702,7 +7702,7 @@ export const pageLabels = {
 	},
 	"seo.partialResults": {
 		en: "Some SEO records are temporarily unavailable. This page is showing partial results.",
-		ar: "Some SEO records are temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض سجلات SEO غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos registros de SEO no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certains enregistrements SEO sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige SEO-Datensätze sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -7714,7 +7714,7 @@ export const pageLabels = {
 	},
 	"seo.indexedRecords": {
 		en: "Indexed SEO records",
-		ar: "Indexed SEO records", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سجلات SEO المفهرسة",
 		es: "Registros SEO indexados",
 		fr: "Enregistrements SEO indexés",
 		de: "Indexierte SEO-Datensätze",
@@ -7726,7 +7726,7 @@ export const pageLabels = {
 	},
 	"seo.indexedRecordsDesc": {
 		en: "Pages, posts, archives, structured pages, and system routes.",
-		ar: "Pages, posts, archives, structured pages, and system routes.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات والمنشورات والأرشيفات والصفحات المنظَّمة ومسارات النظام.",
 		es: "Páginas, publicaciones, archivos, páginas estructuradas y rutas del sistema.",
 		fr: "Pages, articles, archives, pages structurées et routes système.",
 		de: "Seiten, Beiträge, Archive, strukturierte Seiten und Systemrouten.",
@@ -7738,7 +7738,7 @@ export const pageLabels = {
 	},
 	"seo.needsMetadata": {
 		en: "Needs metadata",
-		ar: "Needs metadata", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بحاجة إلى بيانات وصفية",
 		es: "Necesita metadatos",
 		fr: "Métadonnées requises",
 		de: "Metadaten fehlen",
@@ -7750,7 +7750,7 @@ export const pageLabels = {
 	},
 	"seo.needsMetadataDesc": {
 		en: "Items still missing a dedicated SEO title or meta description.",
-		ar: "Items still missing a dedicated SEO title or meta description.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العناصر التي لا تزال تفتقر إلى عنوان SEO مخصّص أو وصف ميتا.",
 		es: "Elementos que aún carecen de un título SEO o meta descripción dedicados.",
 		fr: "Éléments dépourvus d'un titre SEO ou d'une méta-description dédiés.",
 		de: "Elemente, denen noch ein dedizierter SEO-Titel oder eine Meta-Beschreibung fehlt.",
@@ -7762,7 +7762,7 @@ export const pageLabels = {
 	},
 	"seo.triageKicker": {
 		en: "Triage",
-		ar: "Triage", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الفرز",
 		es: "Triaje",
 		fr: "Tri",
 		de: "Triage",
@@ -7774,7 +7774,7 @@ export const pageLabels = {
 	},
 	"seo.triageHeading": {
 		en: "SEO Triage",
-		ar: "SEO Triage", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فرز SEO",
 		es: "Triaje de SEO",
 		fr: "Tri SEO",
 		de: "SEO-Triage",
@@ -7786,7 +7786,7 @@ export const pageLabels = {
 	},
 	"seo.triageDesc": {
 		en: "Filter by record family, isolate missing metadata, then jump into the owning editor.",
-		ar: "Filter by record family, isolate missing metadata, then jump into the owning editor.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفِّ حسب عائلة السجل، اعزل البيانات الوصفية الناقصة، ثم انتقل إلى المحرّر المالك.",
 		es: "Filtra por familia de registros, aísla los metadatos faltantes y salta al editor correspondiente.",
 		fr: "Filtrez par famille d'enregistrements, isolez les métadonnées manquantes, puis accédez à l'éditeur correspondant.",
 		de: "Filtern Sie nach Datensatzfamilie, isolieren Sie fehlende Metadaten und springen Sie in den zuständigen Editor.",
@@ -7798,7 +7798,7 @@ export const pageLabels = {
 	},
 	"seo.sortRowsAria": {
 		en: "Sort SEO rows",
-		ar: "Sort SEO rows", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فرز صفوف SEO",
 		es: "Ordenar filas de SEO",
 		fr: "Trier les lignes SEO",
 		de: "SEO-Zeilen sortieren",
@@ -7810,7 +7810,7 @@ export const pageLabels = {
 	},
 	"seo.sortByPath": {
 		en: "Sort by path",
-		ar: "Sort by path", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الفرز حسب المسار",
 		es: "Ordenar por ruta",
 		fr: "Trier par chemin",
 		de: "Nach Pfad sortieren",
@@ -7822,7 +7822,7 @@ export const pageLabels = {
 	},
 	"seo.sortByTitle": {
 		en: "Sort by title",
-		ar: "Sort by title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الفرز حسب العنوان",
 		es: "Ordenar por título",
 		fr: "Trier par titre",
 		de: "Nach Titel sortieren",
@@ -7834,7 +7834,7 @@ export const pageLabels = {
 	},
 	"seo.sortByType": {
 		en: "Sort by type",
-		ar: "Sort by type", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الفرز حسب النوع",
 		es: "Ordenar por tipo",
 		fr: "Trier par type",
 		de: "Nach Typ sortieren",
@@ -7846,7 +7846,7 @@ export const pageLabels = {
 	},
 	"seo.sortByStatus": {
 		en: "Sort by status",
-		ar: "Sort by status", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الفرز حسب الحالة",
 		es: "Ordenar por estado",
 		fr: "Trier par statut",
 		de: "Nach Status sortieren",
@@ -7858,7 +7858,7 @@ export const pageLabels = {
 	},
 	"seo.apply": {
 		en: "Apply",
-		ar: "Apply", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تطبيق",
 		es: "Aplicar",
 		fr: "Appliquer",
 		de: "Anwenden",
@@ -7870,7 +7870,7 @@ export const pageLabels = {
 	},
 	"seo.ofIndexed": {
 		en: "of",
-		ar: "of", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "من",
 		es: "de",
 		fr: "sur",
 		de: "von",
@@ -7882,7 +7882,7 @@ export const pageLabels = {
 	},
 	"seo.indexedItems": {
 		en: "indexed items",
-		ar: "indexed items", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عناصر مفهرسة",
 		es: "elementos indexados",
 		fr: "éléments indexés",
 		de: "indexierte Elemente",
@@ -7894,7 +7894,7 @@ export const pageLabels = {
 	},
 	"seo.filterAll": {
 		en: "All",
-		ar: "All", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الكل",
 		es: "Todos",
 		fr: "Tous",
 		de: "Alle",
@@ -7906,7 +7906,7 @@ export const pageLabels = {
 	},
 	"seo.filterPages": {
 		en: "Pages",
-		ar: "Pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الصفحات",
 		es: "Páginas",
 		fr: "Pages",
 		de: "Seiten",
@@ -7918,7 +7918,7 @@ export const pageLabels = {
 	},
 	"seo.filterPosts": {
 		en: "Posts",
-		ar: "Posts", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المنشورات",
 		es: "Publicaciones",
 		fr: "Articles",
 		de: "Beiträge",
@@ -7930,7 +7930,7 @@ export const pageLabels = {
 	},
 	"seo.filterStructured": {
 		en: "Structured",
-		ar: "Structured", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "منظَّم",
 		es: "Estructuradas",
 		fr: "Structurées",
 		de: "Strukturiert",
@@ -7942,7 +7942,7 @@ export const pageLabels = {
 	},
 	"seo.filterArchives": {
 		en: "Archives",
-		ar: "Archives", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الأرشيفات",
 		es: "Archivos",
 		fr: "Archives",
 		de: "Archive",
@@ -7954,7 +7954,7 @@ export const pageLabels = {
 	},
 	"seo.filterSystem": {
 		en: "System",
-		ar: "System", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النظام",
 		es: "Sistema",
 		fr: "Système",
 		de: "System",
@@ -7966,7 +7966,7 @@ export const pageLabels = {
 	},
 	"seo.missingOnly": {
 		en: "Missing metadata only",
-		ar: "Missing metadata only", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "البيانات الوصفية المفقودة فقط",
 		es: "Solo metadatos faltantes",
 		fr: "Uniquement métadonnées manquantes",
 		de: "Nur fehlende Metadaten",
@@ -7978,7 +7978,7 @@ export const pageLabels = {
 	},
 	"seo.overview": {
 		en: "SEO metadata overview",
-		ar: "SEO metadata overview", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نظرة عامة على بيانات SEO الوصفية",
 		es: "Resumen de metadatos SEO",
 		fr: "Aperçu des métadonnées SEO",
 		de: "SEO-Metadaten-Übersicht",
@@ -7990,7 +7990,7 @@ export const pageLabels = {
 	},
 	"seo.tableAria": {
 		en: "SEO metadata",
-		ar: "SEO metadata", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بيانات SEO الوصفية",
 		es: "Metadatos SEO",
 		fr: "Métadonnées SEO",
 		de: "SEO-Metadaten",
@@ -8002,7 +8002,7 @@ export const pageLabels = {
 	},
 	"seo.colType": {
 		en: "Type",
-		ar: "Type", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النوع",
 		es: "Tipo",
 		fr: "Type",
 		de: "Typ",
@@ -8014,7 +8014,7 @@ export const pageLabels = {
 	},
 	"seo.colSeoTitle": {
 		en: "SEO Title",
-		ar: "SEO Title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عنوان SEO",
 		es: "Título SEO",
 		fr: "Titre SEO",
 		de: "SEO-Titel",
@@ -8026,7 +8026,7 @@ export const pageLabels = {
 	},
 	"seo.colMetaDescription": {
 		en: "Meta Description",
-		ar: "Meta Description", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "وصف ميتا",
 		es: "Meta descripción",
 		fr: "Méta-description",
 		de: "Meta-Beschreibung",
@@ -8038,7 +8038,7 @@ export const pageLabels = {
 	},
 	"seo.colEdit": {
 		en: "Edit",
-		ar: "Edit", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل",
 		es: "Editar",
 		fr: "Modifier",
 		de: "Bearbeiten",
@@ -8050,7 +8050,7 @@ export const pageLabels = {
 	},
 	"seo.needsWork": {
 		en: "Needs work",
-		ar: "Needs work", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بحاجة إلى عمل",
 		es: "Requiere trabajo",
 		fr: "À compléter",
 		de: "Überarbeitung nötig",
@@ -8062,7 +8062,7 @@ export const pageLabels = {
 	},
 	"seo.ready": {
 		en: "Ready",
-		ar: "Ready", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جاهز",
 		es: "Listo",
 		fr: "Prêt",
 		de: "Bereit",
@@ -8074,7 +8074,7 @@ export const pageLabels = {
 	},
 	"seo.edit": {
 		en: "Edit",
-		ar: "Edit", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعديل",
 		es: "Editar",
 		fr: "Modifier",
 		de: "Bearbeiten",
@@ -8086,7 +8086,7 @@ export const pageLabels = {
 	},
 	"system.title": {
 		en: "System",
-		ar: "System", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النظام",
 		es: "Sistema",
 		fr: "Système",
 		de: "System",
@@ -8098,7 +8098,7 @@ export const pageLabels = {
 	},
 	"system.description": {
 		en: "Admin-owned system routes and generated public outputs.",
-		ar: "Admin-owned system routes and generated public outputs.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسارات النظامية المملوكة للإدارة والمخرجات العامة المُولَّدة.",
 		es: "Rutas de sistema gestionadas por administradores y salidas públicas generadas.",
 		fr: "Routes système gérées par l'administrateur et sorties publiques générées.",
 		de: "Vom Admin verwaltete Systemrouten und generierte öffentliche Ausgaben.",
@@ -8110,7 +8110,7 @@ export const pageLabels = {
 	},
 	"system.partialResults": {
 		en: "Some system-route data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some system-route data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات مسارات النظام غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de rutas del sistema no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de routes système sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Systemrouten-Daten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -8122,7 +8122,7 @@ export const pageLabels = {
 	},
 	"system.backToPages": {
 		en: "Back to pages",
-		ar: "Back to pages", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العودة إلى الصفحات",
 		es: "Volver a páginas",
 		fr: "Retour aux pages",
 		de: "Zurück zu Seiten",
@@ -8134,7 +8134,7 @@ export const pageLabels = {
 	},
 	"system.open500": {
 		en: "Open 500 page",
-		ar: "Open 500 page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح صفحة 500",
 		es: "Abrir página 500",
 		fr: "Ouvrir la page 500",
 		de: "500-Seite öffnen",
@@ -8146,7 +8146,7 @@ export const pageLabels = {
 	},
 	"system.openRobots": {
 		en: "Open robots.txt",
-		ar: "Open robots.txt", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح robots.txt",
 		es: "Abrir robots.txt",
 		fr: "Ouvrir robots.txt",
 		de: "robots.txt öffnen",
@@ -8158,7 +8158,7 @@ export const pageLabels = {
 	},
 	"system.openSitemap": {
 		en: "Open sitemap.xml",
-		ar: "Open sitemap.xml", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح sitemap.xml",
 		es: "Abrir sitemap.xml",
 		fr: "Ouvrir sitemap.xml",
 		de: "sitemap.xml öffnen",
@@ -8170,7 +8170,7 @@ export const pageLabels = {
 	},
 	"system.savedSuccess": {
 		en: "System route updated successfully.",
-		ar: "System route updated successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تحديث مسار النظام بنجاح.",
 		es: "Ruta del sistema actualizada correctamente.",
 		fr: "Route système mise à jour avec succès.",
 		de: "Systemroute erfolgreich aktualisiert.",
@@ -8182,7 +8182,7 @@ export const pageLabels = {
 	},
 	"system.errorSurfaceKicker": {
 		en: "Error Surface",
-		ar: "Error Surface", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سطح الخطأ",
 		es: "Superficie de error",
 		fr: "Surface d'erreur",
 		de: "Fehleroberfläche",
@@ -8194,7 +8194,7 @@ export const pageLabels = {
 	},
 	"system.errorPageHeading": {
 		en: "500 Page",
-		ar: "500 Page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحة 500",
 		es: "Página 500",
 		fr: "Page 500",
 		de: "500-Seite",
@@ -8206,7 +8206,7 @@ export const pageLabels = {
 	},
 	"system.errorPageDesc": {
 		en: "Editor-owned content and CTA settings for the public error page.",
-		ar: "Editor-owned content and CTA settings for the public error page.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "محتوى وإعدادات نداء العمل التي يملكها المحرّر لصفحة الخطأ العامة.",
 		es: "Contenido gestionado por editores y configuración de CTA para la página de error pública.",
 		fr: "Contenu géré par l'éditeur et paramètres CTA pour la page d'erreur publique.",
 		de: "Vom Editor verwaltete Inhalte und CTA-Einstellungen für die öffentliche Fehlerseite.",
@@ -8218,7 +8218,7 @@ export const pageLabels = {
 	},
 	"system.publicRoute": {
 		en: "Public route:",
-		ar: "Public route:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسار العام:",
 		es: "Ruta pública:",
 		fr: "Route publique :",
 		de: "Öffentliche Route:",
@@ -8230,7 +8230,7 @@ export const pageLabels = {
 	},
 	"system.generatedPublicOutput": {
 		en: "Generated public output:",
-		ar: "Generated public output:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المخرجات العامة المُولَّدة:",
 		es: "Salida pública generada:",
 		fr: "Sortie publique générée :",
 		de: "Generierte öffentliche Ausgabe:",
@@ -8242,7 +8242,7 @@ export const pageLabels = {
 	},
 	"system.fieldTitle": {
 		en: "Title",
-		ar: "Title", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العنوان",
 		es: "Título",
 		fr: "Titre",
 		de: "Titel",
@@ -8254,7 +8254,7 @@ export const pageLabels = {
 	},
 	"system.fieldSummary": {
 		en: "Summary",
-		ar: "Summary", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الملخّص",
 		es: "Resumen",
 		fr: "Résumé",
 		de: "Zusammenfassung",
@@ -8266,7 +8266,7 @@ export const pageLabels = {
 	},
 	"system.fieldBody": {
 		en: "Body",
-		ar: "Body", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المحتوى",
 		es: "Cuerpo",
 		fr: "Corps",
 		de: "Inhalt",
@@ -8278,7 +8278,7 @@ export const pageLabels = {
 	},
 	"system.fieldButtonLabel": {
 		en: "Button label",
-		ar: "Button label", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نص الزر",
 		es: "Etiqueta del botón",
 		fr: "Libellé du bouton",
 		de: "Schaltflächenbeschriftung",
@@ -8290,7 +8290,7 @@ export const pageLabels = {
 	},
 	"system.fieldButtonHref": {
 		en: "Button href",
-		ar: "Button href", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط الزر",
 		es: "Enlace del botón (href)",
 		fr: "Lien du bouton (href)",
 		de: "Button-Link (href)",
@@ -8302,7 +8302,7 @@ export const pageLabels = {
 	},
 	"system.fieldContactHref": {
 		en: "Contact href",
-		ar: "Contact href", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط التواصل",
 		es: "Enlace de contacto (href)",
 		fr: "Lien de contact (href)",
 		de: "Kontakt-Link (href)",
@@ -8314,7 +8314,7 @@ export const pageLabels = {
 	},
 	"system.fieldRevisionNote": {
 		en: "Revision note",
-		ar: "Revision note", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ملاحظة المراجعة",
 		es: "Nota de revisión",
 		fr: "Note de révision",
 		de: "Revisionsnotiz",
@@ -8326,7 +8326,7 @@ export const pageLabels = {
 	},
 	"system.revisionPlaceholder": {
 		en: "Summarize this change",
-		ar: "Summarize this change", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لخّص هذا التغيير",
 		es: "Resume este cambio",
 		fr: "Résumez ce changement",
 		de: "Fassen Sie diese Änderung zusammen",
@@ -8338,7 +8338,7 @@ export const pageLabels = {
 	},
 	"system.errorPageDefaultTitle": {
 		en: "Request could not be completed",
-		ar: "Request could not be completed", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تعذّر إكمال الطلب",
 		es: "No se pudo completar la solicitud",
 		fr: "La requête n'a pas pu être traitée",
 		de: "Anfrage konnte nicht abgeschlossen werden",
@@ -8350,7 +8350,7 @@ export const pageLabels = {
 	},
 	"system.errorPageDefaultButton": {
 		en: "Go to homepage",
-		ar: "Go to homepage", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الانتقال إلى الصفحة الرئيسية",
 		es: "Ir a la página de inicio",
 		fr: "Aller à l'accueil",
 		de: "Zur Startseite",
@@ -8362,7 +8362,7 @@ export const pageLabels = {
 	},
 	"system.save500": {
 		en: "Save 500 page",
-		ar: "Save 500 page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ صفحة 500",
 		es: "Guardar página 500",
 		fr: "Enregistrer la page 500",
 		de: "500-Seite speichern",
@@ -8374,7 +8374,7 @@ export const pageLabels = {
 	},
 	"system.crawlerOutputKicker": {
 		en: "Crawler Output",
-		ar: "Crawler Output", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مخرجات الزاحف",
 		es: "Salida del rastreador",
 		fr: "Sortie du robot d'exploration",
 		de: "Crawler-Ausgabe",
@@ -8386,7 +8386,7 @@ export const pageLabels = {
 	},
 	"system.robotsHeading": {
 		en: "robots.txt",
-		ar: "robots.txt", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "robots.txt",
 		es: "robots.txt",
 		fr: "robots.txt",
 		de: "robots.txt",
@@ -8398,7 +8398,7 @@ export const pageLabels = {
 	},
 	"system.robotsDesc": {
 		en: "Managed generated output for crawler rules and sitemap discovery.",
-		ar: "Managed generated output for crawler rules and sitemap discovery.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المخرجات المُولَّدة المُدارة لقواعد الزواحف واكتشاف خريطة الموقع.",
 		es: "Salida generada y administrada para reglas de rastreadores y descubrimiento de sitemap.",
 		fr: "Sortie générée et gérée pour les règles des robots et la découverte du sitemap.",
 		de: "Verwaltete generierte Ausgabe für Crawler-Regeln und Sitemap-Erkennung.",
@@ -8410,7 +8410,7 @@ export const pageLabels = {
 	},
 	"system.saveRobots": {
 		en: "Save robots.txt",
-		ar: "Save robots.txt", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ robots.txt",
 		es: "Guardar robots.txt",
 		fr: "Enregistrer robots.txt",
 		de: "robots.txt speichern",
@@ -8422,7 +8422,7 @@ export const pageLabels = {
 	},
 	"system.robotsDefaultTitle": {
 		en: "Robots",
-		ar: "Robots", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "Robots",
 		es: "Robots",
 		fr: "Robots",
 		de: "Robots",
@@ -8434,7 +8434,7 @@ export const pageLabels = {
 	},
 	"system.generatedSitemapKicker": {
 		en: "Generated Sitemap",
-		ar: "Generated Sitemap", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "خريطة الموقع المُولَّدة",
 		es: "Sitemap generado",
 		fr: "Sitemap généré",
 		de: "Generiertes Sitemap",
@@ -8446,7 +8446,7 @@ export const pageLabels = {
 	},
 	"system.sitemapHeading": {
 		en: "sitemap.xml",
-		ar: "sitemap.xml", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "sitemap.xml",
 		es: "sitemap.xml",
 		fr: "sitemap.xml",
 		de: "sitemap.xml",
@@ -8458,7 +8458,7 @@ export const pageLabels = {
 	},
 	"system.sitemapDesc": {
 		en: "Control exclusions and extra canonical URLs for the generated sitemap.",
-		ar: "Control exclusions and extra canonical URLs for the generated sitemap.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تحكَّم بالاستثناءات والروابط الأساسية الإضافية في خريطة الموقع المُولَّدة.",
 		es: "Controla las exclusiones y las URLs canónicas adicionales para el sitemap generado.",
 		fr: "Contrôlez les exclusions et les URL canoniques supplémentaires pour le sitemap généré.",
 		de: "Steuern Sie Ausschlüsse und zusätzliche kanonische URLs für das generierte Sitemap.",
@@ -8470,7 +8470,7 @@ export const pageLabels = {
 	},
 	"system.fieldExcludedPaths": {
 		en: "Excluded paths",
-		ar: "Excluded paths", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المسارات المستثناة",
 		es: "Rutas excluidas",
 		fr: "Chemins exclus",
 		de: "Ausgeschlossene Pfade",
@@ -8482,7 +8482,7 @@ export const pageLabels = {
 	},
 	"system.fieldExtraUrls": {
 		en: "Extra canonical URLs",
-		ar: "Extra canonical URLs", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "روابط أساسية إضافية",
 		es: "URLs canónicas adicionales",
 		fr: "URL canoniques supplémentaires",
 		de: "Zusätzliche kanonische URLs",
@@ -8494,7 +8494,7 @@ export const pageLabels = {
 	},
 	"system.saveSitemap": {
 		en: "Save sitemap.xml",
-		ar: "Save sitemap.xml", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حفظ sitemap.xml",
 		es: "Guardar sitemap.xml",
 		fr: "Enregistrer sitemap.xml",
 		de: "sitemap.xml speichern",
@@ -8506,7 +8506,7 @@ export const pageLabels = {
 	},
 	"system.sitemapDefaultTitle": {
 		en: "Sitemap",
-		ar: "Sitemap", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "خريطة الموقع",
 		es: "Sitemap",
 		fr: "Sitemap",
 		de: "Sitemap",
@@ -8518,7 +8518,7 @@ export const pageLabels = {
 	},
 	"system.forbiddenBody": {
 		en: "This action requires an admin account and is hidden from editor-only roles.",
-		ar: "This action requires an admin account and is hidden from editor-only roles.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "يتطلب هذا الإجراء حساب مسؤول وهو مخفي عن الأدوار المحرّرة فقط.",
 		es: "Esta acción requiere una cuenta de administración y está oculta para roles solo de editor.",
 		fr: "Cette action nécessite un compte administrateur et est masquée pour les rôles éditeur uniquement.",
 		de: "Diese Aktion erfordert ein Admin-Konto und ist für reine Editor-Rollen ausgeblendet.",
@@ -8530,7 +8530,7 @@ export const pageLabels = {
 	},
 	"apiTokens.title": {
 		en: "API Tokens",
-		ar: "API Tokens", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رموز واجهة برمجة التطبيقات",
 		es: "Tokens de API",
 		fr: "Jetons API",
 		de: "API-Token",
@@ -8542,7 +8542,7 @@ export const pageLabels = {
 	},
 	"apiTokens.description": {
 		en: "Manage API tokens for programmatic access.",
-		ar: "Manage API tokens for programmatic access.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر رموز واجهة برمجة التطبيقات للوصول البرمجي.",
 		es: "Gestiona los tokens de API para acceso programático.",
 		fr: "Gérez les jetons API pour un accès programmatique.",
 		de: "Verwalten Sie API-Token für den programmgesteuerten Zugriff.",
@@ -8554,7 +8554,7 @@ export const pageLabels = {
 	},
 	"apiTokens.revokedSuccess": {
 		en: "Token revoked successfully.",
-		ar: "Token revoked successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم إلغاء الرمز بنجاح.",
 		es: "Token revocado correctamente.",
 		fr: "Jeton révoqué avec succès.",
 		de: "Token erfolgreich widerrufen.",
@@ -8566,7 +8566,7 @@ export const pageLabels = {
 	},
 	"apiTokens.created": {
 		en: "Token created.",
-		ar: "Token created.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم إنشاء الرمز.",
 		es: "Token creado.",
 		fr: "Jeton créé.",
 		de: "Token erstellt.",
@@ -8578,7 +8578,7 @@ export const pageLabels = {
 	},
 	"apiTokens.copyNow": {
 		en: "Copy this token now — it will not be shown again.",
-		ar: "Copy this token now — it will not be shown again.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "انسخ هذا الرمز الآن — لن يظهر مجددًا.",
 		es: "Copia este token ahora; no se mostrará de nuevo.",
 		fr: "Copiez ce jeton maintenant — il ne sera plus affiché.",
 		de: "Kopieren Sie diesen Token jetzt — er wird nicht erneut angezeigt.",
@@ -8590,7 +8590,7 @@ export const pageLabels = {
 	},
 	"apiTokens.createKicker": {
 		en: "Create Token",
-		ar: "Create Token", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إنشاء رمز",
 		es: "Crear token",
 		fr: "Créer un jeton",
 		de: "Token erstellen",
@@ -8602,7 +8602,7 @@ export const pageLabels = {
 	},
 	"apiTokens.newToken": {
 		en: "New API Token",
-		ar: "New API Token", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رمز واجهة برمجة تطبيقات جديد",
 		es: "Nuevo token de API",
 		fr: "Nouveau jeton API",
 		de: "Neues API-Token",
@@ -8614,7 +8614,7 @@ export const pageLabels = {
 	},
 	"apiTokens.label": {
 		en: "Label",
-		ar: "Label", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التسمية",
 		es: "Etiqueta",
 		fr: "Libellé",
 		de: "Beschriftung",
@@ -8626,7 +8626,7 @@ export const pageLabels = {
 	},
 	"apiTokens.labelPlaceholder": {
 		en: "e.g. AI assistant",
-		ar: "e.g. AI assistant", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مثال: مساعد ذكاء اصطناعي",
 		es: "p. ej. asistente de IA",
 		fr: "p. ex. assistant IA",
 		de: "z. B. KI-Assistent",
@@ -8638,7 +8638,7 @@ export const pageLabels = {
 	},
 	"apiTokens.scopes": {
 		en: "Scopes",
-		ar: "Scopes", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النطاقات",
 		es: "Ámbitos",
 		fr: "Portées",
 		de: "Bereiche",
@@ -8650,7 +8650,7 @@ export const pageLabels = {
 	},
 	"apiTokens.createButton": {
 		en: "Create Token",
-		ar: "Create Token", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إنشاء رمز",
 		es: "Crear token",
 		fr: "Créer un jeton",
 		de: "Token erstellen",
@@ -8662,7 +8662,7 @@ export const pageLabels = {
 	},
 	"apiTokens.existingTokens": {
 		en: "Existing Tokens",
-		ar: "Existing Tokens", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الرموز الحالية",
 		es: "Tokens existentes",
 		fr: "Jetons existants",
 		de: "Vorhandene Token",
@@ -8674,7 +8674,7 @@ export const pageLabels = {
 	},
 	"apiTokens.noTokens": {
 		en: "No tokens yet. Create one above.",
-		ar: "No tokens yet. Create one above.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد رموز بعد. أنشئ واحدًا أعلاه.",
 		es: "Aún no hay tokens. Crea uno arriba.",
 		fr: "Aucun jeton pour le moment. Créez-en un ci-dessus.",
 		de: "Noch keine Token. Erstellen Sie oben einen.",
@@ -8686,7 +8686,7 @@ export const pageLabels = {
 	},
 	"apiTokens.colCreated": {
 		en: "Created",
-		ar: "Created", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم الإنشاء",
 		es: "Creado",
 		fr: "Créé",
 		de: "Erstellt",
@@ -8698,7 +8698,7 @@ export const pageLabels = {
 	},
 	"apiTokens.colLastUsed": {
 		en: "Last Used",
-		ar: "Last Used", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "آخر استخدام",
 		es: "Último uso",
 		fr: "Dernière utilisation",
 		de: "Zuletzt verwendet",
@@ -8710,7 +8710,7 @@ export const pageLabels = {
 	},
 	"apiTokens.never": {
 		en: "Never",
-		ar: "Never", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أبدًا",
 		es: "Nunca",
 		fr: "Jamais",
 		de: "Nie",
@@ -8722,7 +8722,7 @@ export const pageLabels = {
 	},
 	"apiTokens.revoked": {
 		en: "Revoked",
-		ar: "Revoked", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مُلغًى",
 		es: "Revocado",
 		fr: "Révoqué",
 		de: "Widerrufen",
@@ -8734,7 +8734,7 @@ export const pageLabels = {
 	},
 	"apiTokens.active": {
 		en: "Active",
-		ar: "Active", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نشِط",
 		es: "Activo",
 		fr: "Actif",
 		de: "Aktiv",
@@ -8746,7 +8746,7 @@ export const pageLabels = {
 	},
 	"apiTokens.revoke": {
 		en: "Revoke",
-		ar: "Revoke", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Revocar",
 		fr: "Révoquer",
 		de: "Widerrufen",
@@ -8758,7 +8758,7 @@ export const pageLabels = {
 	},
 	"apiTokens.confirmTitle": {
 		en: "Revoke API token?",
-		ar: "Revoke API token?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء رمز واجهة برمجة التطبيقات؟",
 		es: "¿Revocar el token de API?",
 		fr: "Révoquer le jeton API ?",
 		de: "API-Token widerrufen?",
@@ -8770,7 +8770,7 @@ export const pageLabels = {
 	},
 	"apiTokens.confirmBody": {
 		en: "Are you sure you want to revoke",
-		ar: "Are you sure you want to revoke", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد إلغاء",
 		es: "¿Seguro que quieres revocar",
 		fr: "Êtes-vous sûr de vouloir révoquer",
 		de: "Möchten Sie wirklich widerrufen",
@@ -8782,7 +8782,7 @@ export const pageLabels = {
 	},
 	"apiTokens.confirmWarning": {
 		en: "Revoked tokens cannot be restored. Any integrations using this token will stop working.",
-		ar: "Revoked tokens cannot be restored. Any integrations using this token will stop working.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يمكن استرداد الرموز المُلغاة. ستتوقّف أي تكاملات تستخدم هذا الرمز عن العمل.",
 		es: "Los tokens revocados no se pueden restaurar. Las integraciones que usen este token dejarán de funcionar.",
 		fr: "Les jetons révoqués ne peuvent pas être restaurés. Toutes les intégrations utilisant ce jeton cesseront de fonctionner.",
 		de: "Widerrufene Token können nicht wiederhergestellt werden. Alle Integrationen, die dieses Token verwenden, funktionieren nicht mehr.",
@@ -8794,7 +8794,7 @@ export const pageLabels = {
 	},
 	"apiTokens.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -8806,7 +8806,7 @@ export const pageLabels = {
 	},
 	"apiTokens.revokeButton": {
 		en: "Revoke Token",
-		ar: "Revoke Token", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء الرمز",
 		es: "Revocar token",
 		fr: "Révoquer le jeton",
 		de: "Token widerrufen",
@@ -8818,7 +8818,7 @@ export const pageLabels = {
 	},
 	"webhooks.title": {
 		en: "Webhooks",
-		ar: "Webhooks", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "خطافات الويب",
 		es: "Webhooks",
 		fr: "Webhooks",
 		de: "Webhooks",
@@ -8830,7 +8830,7 @@ export const pageLabels = {
 	},
 	"webhooks.description": {
 		en: "Register webhook endpoints to receive real-time event notifications.",
-		ar: "Register webhook endpoints to receive real-time event notifications.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سجِّل نقاط نهاية خطافات الويب لاستقبال إشعارات الأحداث في الوقت الفعلي.",
 		es: "Registra los endpoints de webhook para recibir notificaciones de eventos en tiempo real.",
 		fr: "Enregistrez des points de terminaison de webhook pour recevoir des notifications d'événements en temps réel.",
 		de: "Registrieren Sie Webhook-Endpunkte, um Ereignisbenachrichtigungen in Echtzeit zu erhalten.",
@@ -8842,7 +8842,7 @@ export const pageLabels = {
 	},
 	"webhooks.deletedSuccess": {
 		en: "Webhook deleted successfully.",
-		ar: "Webhook deleted successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم حذف خطاف الويب بنجاح.",
 		es: "Webhook eliminado correctamente.",
 		fr: "Webhook supprimé avec succès.",
 		de: "Webhook erfolgreich gelöscht.",
@@ -8854,7 +8854,7 @@ export const pageLabels = {
 	},
 	"webhooks.created": {
 		en: "Webhook created.",
-		ar: "Webhook created.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم إنشاء خطاف الويب.",
 		es: "Webhook creado.",
 		fr: "Webhook créé.",
 		de: "Webhook erstellt.",
@@ -8866,7 +8866,7 @@ export const pageLabels = {
 	},
 	"webhooks.copyBundle": {
 		en: "Copy this verification bundle now — it will not be shown again.",
-		ar: "Copy this verification bundle now — it will not be shown again.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "انسخ حزمة التحقّق هذه الآن — لن تظهر مجددًا.",
 		es: "Copia este paquete de verificación ahora; no se mostrará de nuevo.",
 		fr: "Copiez ce paquet de vérification maintenant — il ne sera plus affiché.",
 		de: "Kopieren Sie dieses Verifizierungspaket jetzt — es wird nicht erneut angezeigt.",
@@ -8878,7 +8878,7 @@ export const pageLabels = {
 	},
 	"webhooks.useToVerify": {
 		en: "Use it to verify the",
-		ar: "Use it to verify the", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "استخدمه للتحقّق من",
 		es: "Úsalo para verificar el",
 		fr: "Utilisez-le pour vérifier l'en-tête",
 		de: "Verwenden Sie es, um den Header",
@@ -8890,7 +8890,7 @@ export const pageLabels = {
 	},
 	"webhooks.headerSuffix": {
 		en: "header on incoming webhook requests.",
-		ar: "header on incoming webhook requests.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "ترويسة على طلبات خطاف الويب الواردة.",
 		es: "encabezado en las solicitudes entrantes de webhook.",
 		fr: "des requêtes webhook entrantes.",
 		de: "bei eingehenden Webhook-Anfragen zu prüfen.",
@@ -8902,7 +8902,7 @@ export const pageLabels = {
 	},
 	"webhooks.registerKicker": {
 		en: "Register",
-		ar: "Register", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تسجيل",
 		es: "Registrar",
 		fr: "Enregistrer",
 		de: "Registrieren",
@@ -8914,7 +8914,7 @@ export const pageLabels = {
 	},
 	"webhooks.newWebhook": {
 		en: "New Webhook",
-		ar: "New Webhook", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "خطاف ويب جديد",
 		es: "Nuevo webhook",
 		fr: "Nouveau webhook",
 		de: "Neuer Webhook",
@@ -8926,7 +8926,7 @@ export const pageLabels = {
 	},
 	"webhooks.endpointUrl": {
 		en: "Endpoint URL",
-		ar: "Endpoint URL", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رابط نقطة النهاية",
 		es: "URL del endpoint",
 		fr: "URL du point de terminaison",
 		de: "Endpunkt-URL",
@@ -8938,7 +8938,7 @@ export const pageLabels = {
 	},
 	"webhooks.events": {
 		en: "Events",
-		ar: "Events", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الأحداث",
 		es: "Eventos",
 		fr: "Événements",
 		de: "Ereignisse",
@@ -8950,7 +8950,7 @@ export const pageLabels = {
 	},
 	"webhooks.registerButton": {
 		en: "Register Webhook",
-		ar: "Register Webhook", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تسجيل خطاف ويب",
 		es: "Registrar webhook",
 		fr: "Enregistrer le webhook",
 		de: "Webhook registrieren",
@@ -8962,7 +8962,7 @@ export const pageLabels = {
 	},
 	"webhooks.activeWebhooks": {
 		en: "Active Webhooks",
-		ar: "Active Webhooks", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "خطافات الويب النشطة",
 		es: "Webhooks activos",
 		fr: "Webhooks actifs",
 		de: "Aktive Webhooks",
@@ -8974,7 +8974,7 @@ export const pageLabels = {
 	},
 	"webhooks.noWebhooks": {
 		en: "No webhooks yet. Register one above.",
-		ar: "No webhooks yet. Register one above.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد خطافات ويب بعد. سجِّل واحدًا أعلاه.",
 		es: "Aún no hay webhooks. Registra uno arriba.",
 		fr: "Aucun webhook pour le moment. Enregistrez-en un ci-dessus.",
 		de: "Noch keine Webhooks. Registrieren Sie oben einen.",
@@ -8986,7 +8986,7 @@ export const pageLabels = {
 	},
 	"webhooks.colUrl": {
 		en: "URL",
-		ar: "URL", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الرابط",
 		es: "URL",
 		fr: "URL",
 		de: "URL",
@@ -8998,7 +8998,7 @@ export const pageLabels = {
 	},
 	"webhooks.colCreated": {
 		en: "Created",
-		ar: "Created", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم الإنشاء",
 		es: "Creado",
 		fr: "Créé",
 		de: "Erstellt",
@@ -9010,7 +9010,7 @@ export const pageLabels = {
 	},
 	"webhooks.colLastFired": {
 		en: "Last Fired",
-		ar: "Last Fired", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "آخر إطلاق",
 		es: "Último disparo",
 		fr: "Dernier déclenchement",
 		de: "Zuletzt ausgelöst",
@@ -9022,7 +9022,7 @@ export const pageLabels = {
 	},
 	"webhooks.never": {
 		en: "Never",
-		ar: "Never", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أبدًا",
 		es: "Nunca",
 		fr: "Jamais",
 		de: "Nie",
@@ -9034,7 +9034,7 @@ export const pageLabels = {
 	},
 	"webhooks.delete": {
 		en: "Delete",
-		ar: "Delete", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف",
 		es: "Eliminar",
 		fr: "Supprimer",
 		de: "Löschen",
@@ -9046,7 +9046,7 @@ export const pageLabels = {
 	},
 	"webhooks.confirmTitle": {
 		en: "Delete webhook?",
-		ar: "Delete webhook?", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف خطاف الويب؟",
 		es: "¿Eliminar el webhook?",
 		fr: "Supprimer le webhook ?",
 		de: "Webhook löschen?",
@@ -9058,7 +9058,7 @@ export const pageLabels = {
 	},
 	"webhooks.confirmBody": {
 		en: "Are you sure you want to delete the webhook for",
-		ar: "Are you sure you want to delete the webhook for", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "هل تريد بالتأكيد حذف خطاف الويب الخاص بـ",
 		es: "¿Seguro que quieres eliminar el webhook de",
 		fr: "Êtes-vous sûr de vouloir supprimer le webhook pour",
 		de: "Möchten Sie den Webhook wirklich löschen für",
@@ -9070,7 +9070,7 @@ export const pageLabels = {
 	},
 	"webhooks.confirmWarning": {
 		en: "This action cannot be undone.",
-		ar: "This action cannot be undone.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا يمكن التراجع عن هذا الإجراء.",
 		es: "Esta acción no se puede deshacer.",
 		fr: "Cette action est irréversible.",
 		de: "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -9082,7 +9082,7 @@ export const pageLabels = {
 	},
 	"webhooks.cancel": {
 		en: "Cancel",
-		ar: "Cancel", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء",
 		es: "Cancelar",
 		fr: "Annuler",
 		de: "Abbrechen",
@@ -9094,7 +9094,7 @@ export const pageLabels = {
 	},
 	"webhooks.deleteButton": {
 		en: "Delete Webhook",
-		ar: "Delete Webhook", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "حذف خطاف الويب",
 		es: "Eliminar webhook",
 		fr: "Supprimer le webhook",
 		de: "Webhook löschen",
@@ -9107,7 +9107,7 @@ export const pageLabels = {
 	// ANCHOR-BATCH-E: services + fundraising + testimonials
 	"services.title": {
 		en: "Services",
-		ar: "Services", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الخدمات",
 		es: "Servicios",
 		fr: "Services",
 		de: "Dienste",
@@ -9119,7 +9119,7 @@ export const pageLabels = {
 	},
 	"services.description": {
 		en: "Manage integrated headless services: CMS, commerce, community, and email.",
-		ar: "Manage integrated headless services: CMS, commerce, community, and email.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر الخدمات المدمَجة بلا واجهة: نظام إدارة المحتوى، والتجارة، والمجتمع، والبريد.",
 		es: "Gestiona los servicios headless integrados: CMS, comercio, comunidad y correo.",
 		fr: "Gérez les services headless intégrés : CMS, commerce, communauté et e-mail.",
 		de: "Integrierte Headless-Dienste verwalten: CMS, Commerce, Community und E-Mail.",
@@ -9131,7 +9131,7 @@ export const pageLabels = {
 	},
 	"services.emptyKicker": {
 		en: "No services configured",
-		ar: "No services configured", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد خدمات مهيَّأة",
 		es: "Ningún servicio configurado",
 		fr: "Aucun service configuré",
 		de: "Keine Dienste konfiguriert",
@@ -9143,7 +9143,7 @@ export const pageLabels = {
 	},
 	"services.emptyHeading": {
 		en: "Add integrations to your project",
-		ar: "Add integrations to your project", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أضِف التكاملات إلى مشروعك",
 		es: "Añade integraciones a tu proyecto",
 		fr: "Ajoutez des intégrations à votre projet",
 		de: "Integrationen zu Ihrem Projekt hinzufügen",
@@ -9155,7 +9155,7 @@ export const pageLabels = {
 	},
 	"services.emptyIntro": {
 		en: "Register optional headless services to access their admin UIs from this tab. Available integrations:",
-		ar: "Register optional headless services to access their admin UIs from this tab. Available integrations:", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سجِّل الخدمات الاختيارية بلا واجهة للوصول إلى واجهات إدارتها من هذا التبويب. التكاملات المتاحة:",
 		es: "Registra servicios headless opcionales para acceder a sus paneles de administración desde esta pestaña. Integraciones disponibles:",
 		fr: "Enregistrez des services headless optionnels pour accéder à leurs interfaces d'administration depuis cet onglet. Intégrations disponibles :",
 		de: "Registrieren Sie optionale Headless-Dienste, um ihre Admin-Oberflächen von dieser Registerkarte aus zu erreichen. Verfügbare Integrationen:",
@@ -9167,7 +9167,7 @@ export const pageLabels = {
 	},
 	"services.cmsDescription": {
 		en: "Headless CMS — content modelling, editorial UI, media management.",
-		ar: "Headless CMS — content modelling, editorial UI, media management.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نظام إدارة محتوى بلا واجهة — نمذجة المحتوى وواجهة التحرير وإدارة الوسائط.",
 		es: "CMS headless — modelado de contenido, interfaz editorial, gestión de medios.",
 		fr: "CMS headless — modélisation de contenu, interface éditoriale, gestion des médias.",
 		de: "Headless-CMS – Inhaltsmodellierung, redaktionelle Oberfläche, Medienverwaltung.",
@@ -9179,7 +9179,7 @@ export const pageLabels = {
 	},
 	"services.shopDescription": {
 		en: "Headless commerce — products, cart, orders, fulfilment.",
-		ar: "Headless commerce — products, cart, orders, fulfilment.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تجارة بلا واجهة — منتجات وسلة وطلبات وتنفيذ.",
 		es: "Comercio headless — productos, carrito, pedidos, cumplimiento.",
 		fr: "Commerce headless — produits, panier, commandes, traitement.",
 		de: "Headless-Commerce – Produkte, Warenkorb, Bestellungen, Fulfilment.",
@@ -9191,7 +9191,7 @@ export const pageLabels = {
 	},
 	"services.communityDescription": {
 		en: "Comments and community — Giscus (zero server) or Remark42 (self-hosted).",
-		ar: "Comments and community — Giscus (zero server) or Remark42 (self-hosted).", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التعليقات والمجتمع — Giscus (بدون خادم) أو Remark42 (مستضاف ذاتيًا).",
 		es: "Comentarios y comunidad — Giscus (sin servidor) o Remark42 (autoalojado).",
 		fr: "Commentaires et communauté — Giscus (sans serveur) ou Remark42 (auto-hébergé).",
 		de: "Kommentare und Community – Giscus (ohne Server) oder Remark42 (selbst gehostet).",
@@ -9203,7 +9203,7 @@ export const pageLabels = {
 	},
 	"services.emailDescription": {
 		en: "Newsletter and campaigns — Listmonk (self-hosted, MIT).",
-		ar: "Newsletter and campaigns — Listmonk (self-hosted, MIT).", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "النشرة البريدية والحملات — Listmonk (مستضاف ذاتيًا، ترخيص MIT).",
 		es: "Boletín y campañas — Listmonk (autoalojado, MIT).",
 		fr: "Newsletter et campagnes — Listmonk (auto-hébergé, MIT).",
 		de: "Newsletter und Kampagnen – Listmonk (selbst gehostet, MIT).",
@@ -9215,7 +9215,7 @@ export const pageLabels = {
 	},
 	"services.viewDocs": {
 		en: "View docs ↗",
-		ar: "View docs ↗", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عرض التوثيق ↗",
 		es: "Ver documentación ↗",
 		fr: "Voir la documentation ↗",
 		de: "Dokumentation anzeigen ↗",
@@ -9227,7 +9227,7 @@ export const pageLabels = {
 	},
 	"services.setupNoteBefore": {
 		en: "Call",
-		ar: "Call", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اتصال",
 		es: "Llama a",
 		fr: "Appelez",
 		de: "Rufen Sie",
@@ -9239,7 +9239,7 @@ export const pageLabels = {
 	},
 	"services.setupNoteMiddle": {
 		en: "in your Astro integration or",
-		ar: "in your Astro integration or", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "في تكامل Astro الخاص بك أو",
 		es: "en tu integración de Astro o",
 		fr: "dans votre intégration Astro ou",
 		de: "in Ihrer Astro-Integration oder",
@@ -9251,7 +9251,7 @@ export const pageLabels = {
 	},
 	"services.setupNoteAfter": {
 		en: "to enable a service.",
-		ar: "to enable a service.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لتفعيل خدمة.",
 		es: "para habilitar un servicio.",
 		fr: "pour activer un service.",
 		de: "um einen Dienst zu aktivieren.",
@@ -9263,7 +9263,7 @@ export const pageLabels = {
 	},
 	"services.seeDocsBefore": {
 		en: "See",
-		ar: "See", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اطّلع على",
 		es: "Consulta",
 		fr: "Consultez",
 		de: "Siehe",
@@ -9275,7 +9275,7 @@ export const pageLabels = {
 	},
 	"services.seeDocsLink": {
 		en: "the docs",
-		ar: "the docs", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التوثيق",
 		es: "la documentación",
 		fr: "la documentation",
 		de: "die Dokumentation",
@@ -9287,7 +9287,7 @@ export const pageLabels = {
 	},
 	"services.seeDocsAfter": {
 		en: "for setup guides.",
-		ar: "for setup guides.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لأدلة الإعداد.",
 		es: "para guías de configuración.",
 		fr: "pour les guides de configuration.",
 		de: "für Einrichtungsanleitungen.",
@@ -9299,7 +9299,7 @@ export const pageLabels = {
 	},
 	"services.openAdmin": {
 		en: "Open admin →",
-		ar: "Open admin →", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح الإدارة ←",
 		es: "Abrir administración →",
 		fr: "Ouvrir l'administration →",
 		de: "Verwaltung öffnen →",
@@ -9311,7 +9311,7 @@ export const pageLabels = {
 	},
 	"services.notConfiguredTitle": {
 		en: "Service not configured",
-		ar: "Service not configured", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الخدمة غير مهيَّأة",
 		es: "Servicio no configurado",
 		fr: "Service non configuré",
 		de: "Dienst nicht konfiguriert",
@@ -9323,7 +9323,7 @@ export const pageLabels = {
 	},
 	"services.notConfiguredDescription": {
 		en: "This service integration is not registered.",
-		ar: "This service integration is not registered.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تكامل هذه الخدمة غير مسجَّل.",
 		es: "Esta integración de servicio no está registrada.",
 		fr: "Cette intégration de service n'est pas enregistrée.",
 		de: "Diese Dienstintegration ist nicht registriert.",
@@ -9335,7 +9335,7 @@ export const pageLabels = {
 	},
 	"services.notFound": {
 		en: "Not found",
-		ar: "Not found", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "غير موجود",
 		es: "No encontrado",
 		fr: "Introuvable",
 		de: "Nicht gefunden",
@@ -9347,7 +9347,7 @@ export const pageLabels = {
 	},
 	"services.notRegisteredBefore": {
 		en: "There is no service registered for provider",
-		ar: "There is no service registered for provider", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد خدمة مسجَّلة للموفّر",
 		es: "No hay ningún servicio registrado para el proveedor",
 		fr: "Aucun service n'est enregistré pour le fournisseur",
 		de: "Für den Anbieter ist kein Dienst registriert",
@@ -9359,7 +9359,7 @@ export const pageLabels = {
 	},
 	"services.notRegisteredAfter": {
 		en: "Register it by calling",
-		ar: "Register it by calling", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "سجِّله بمناداة",
 		es: "Regístralo llamando a",
 		fr: "Enregistrez-le en appelant",
 		de: "Registrieren Sie ihn, indem Sie",
@@ -9371,7 +9371,7 @@ export const pageLabels = {
 	},
 	"services.notRegisteredEnd": {
 		en: "in your Astro config.",
-		ar: "in your Astro config.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "في إعدادات Astro الخاصة بك.",
 		es: "en tu configuración de Astro.",
 		fr: "dans votre configuration Astro.",
 		de: "in Ihrer Astro-Konfiguration aufrufen.",
@@ -9383,7 +9383,7 @@ export const pageLabels = {
 	},
 	"services.backToServices": {
 		en: "Back to Services",
-		ar: "Back to Services", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "العودة إلى الخدمات",
 		es: "Volver a Servicios",
 		fr: "Retour aux services",
 		de: "Zurück zu den Diensten",
@@ -9395,7 +9395,7 @@ export const pageLabels = {
 	},
 	"services.allServices": {
 		en: "← All services",
-		ar: "← All services", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "← كل الخدمات",
 		es: "← Todos los servicios",
 		fr: "← Tous les services",
 		de: "← Alle Dienste",
@@ -9407,7 +9407,7 @@ export const pageLabels = {
 	},
 	"services.openInNewTab": {
 		en: "Open in new tab ↗",
-		ar: "Open in new tab ↗", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "فتح في علامة تبويب جديدة ↗",
 		es: "Abrir en pestaña nueva ↗",
 		fr: "Ouvrir dans un nouvel onglet ↗",
 		de: "In neuem Tab öffnen ↗",
@@ -9419,7 +9419,7 @@ export const pageLabels = {
 	},
 	"services.adminFrameTitle": {
 		en: "admin",
-		ar: "admin", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مسؤول",
 		es: "administración",
 		fr: "administration",
 		de: "Verwaltung",
@@ -9431,7 +9431,7 @@ export const pageLabels = {
 	},
 	"fundraising.title": {
 		en: "Fundraising",
-		ar: "Fundraising", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "جمع التبرعات",
 		es: "Recaudación",
 		fr: "Collecte de fonds",
 		de: "Fundraising",
@@ -9443,7 +9443,7 @@ export const pageLabels = {
 	},
 	"fundraising.description": {
 		en: "Configured donation providers for this site",
-		ar: "Configured donation providers for this site", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "موفّرو التبرعات المهيَّؤون لهذا الموقع",
 		es: "Proveedores de donaciones configurados para este sitio",
 		fr: "Fournisseurs de dons configurés pour ce site",
 		de: "Konfigurierte Spendenanbieter für diese Website",
@@ -9455,7 +9455,7 @@ export const pageLabels = {
 	},
 	"fundraising.kicker": {
 		en: "Donation Providers",
-		ar: "Donation Providers", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "موفّرو التبرعات",
 		es: "Proveedores de donaciones",
 		fr: "Fournisseurs de dons",
 		de: "Spendenanbieter",
@@ -9467,7 +9467,7 @@ export const pageLabels = {
 	},
 	"fundraising.intro": {
 		en: "The following donation providers are enabled. Widgets appear on your",
-		ar: "The following donation providers are enabled. Widgets appear on your", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "موفّرو التبرعات التاليون مُفعَّلون. تظهر العناصر على",
 		es: "Los siguientes proveedores de donaciones están habilitados. Los widgets aparecen en tu",
 		fr: "Les fournisseurs de dons suivants sont activés. Les widgets apparaissent sur votre",
 		de: "Die folgenden Spendenanbieter sind aktiviert. Widgets erscheinen auf Ihrer",
@@ -9479,7 +9479,7 @@ export const pageLabels = {
 	},
 	"fundraising.donatePageLink": {
 		en: "/donate page",
-		ar: "/donate page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "صفحة /donate",
 		es: "página /donate",
 		fr: "page /donate",
 		de: "/donate-Seite",
@@ -9491,7 +9491,7 @@ export const pageLabels = {
 	},
 	"fundraising.giveLivelyDescription": {
 		en: "Fiat donations for US nonprofits. Widget embedded on your /donate page.",
-		ar: "Fiat donations for US nonprofits. Widget embedded on your /donate page.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تبرعات نقدية للجمعيات غير الربحية في الولايات المتحدة. عُنصر مضمَّن في صفحة /donate.",
 		es: "Donaciones en dinero fiat para organizaciones sin fines de lucro de EE. UU. Widget integrado en tu página /donate.",
 		fr: "Dons en monnaie fiduciaire pour les organisations à but non lucratif américaines. Widget intégré à votre page /donate.",
 		de: "Fiat-Spenden für US-amerikanische Non-Profits. Widget in Ihre /donate-Seite eingebettet.",
@@ -9503,7 +9503,7 @@ export const pageLabels = {
 	},
 	"fundraising.liberapayDescription": {
 		en: "Recurring fiat donations. Static button on your /donate page — no external scripts.",
-		ar: "Recurring fiat donations. Static button on your /donate page — no external scripts.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تبرعات نقدية متكرّرة. زر ثابت في صفحة /donate — بلا برامج نصية خارجية.",
 		es: "Donaciones fiat recurrentes. Botón estático en tu página /donate, sin scripts externos.",
 		fr: "Dons fiat récurrents. Bouton statique sur votre page /donate — pas de scripts externes.",
 		de: "Wiederkehrende Fiat-Spenden. Statische Schaltfläche auf Ihrer /donate-Seite – ohne externe Skripte.",
@@ -9515,7 +9515,7 @@ export const pageLabels = {
 	},
 	"fundraising.pledgeCryptoDescription": {
 		en: "Crypto donations with automatic carbon offsets per transaction.",
-		ar: "Crypto donations with automatic carbon offsets per transaction.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تبرعات بالعملات الرقمية مع تعويض كربوني تلقائي لكل عملية.",
 		es: "Donaciones en cripto con compensaciones de carbono automáticas por transacción.",
 		fr: "Dons en cryptomonnaie avec compensations carbone automatiques par transaction.",
 		de: "Krypto-Spenden mit automatischen CO2-Kompensationen pro Transaktion.",
@@ -9527,7 +9527,7 @@ export const pageLabels = {
 	},
 	"fundraising.configured": {
 		en: "Configured",
-		ar: "Configured", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مُهيَّأ",
 		es: "Configurado",
 		fr: "Configuré",
 		de: "Konfiguriert",
@@ -9539,7 +9539,7 @@ export const pageLabels = {
 	},
 	"fundraising.needsConfig": {
 		en: "Needs config",
-		ar: "Needs config", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بحاجة إلى تهيئة",
 		es: "Necesita configuración",
 		fr: "Configuration requise",
 		de: "Konfiguration nötig",
@@ -9551,7 +9551,7 @@ export const pageLabels = {
 	},
 	"fundraising.viewDonatePage": {
 		en: "View /donate page",
-		ar: "View /donate page", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عرض صفحة /donate",
 		es: "Ver página /donate",
 		fr: "Voir la page /donate",
 		de: "/donate-Seite anzeigen",
@@ -9563,7 +9563,7 @@ export const pageLabels = {
 	},
 	"testimonials.title": {
 		en: "Testimonials",
-		ar: "Testimonials", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإفادات",
 		es: "Testimonios",
 		fr: "Témoignages",
 		de: "Referenzen",
@@ -9575,7 +9575,7 @@ export const pageLabels = {
 	},
 	"testimonials.description": {
 		en: "Review and moderate testimonial submissions.",
-		ar: "Review and moderate testimonial submissions.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "راجع إفادات العملاء المُرسَلة وأشرف عليها.",
 		es: "Revisa y modera las publicaciones de testimonios.",
 		fr: "Examinez et modérez les soumissions de témoignages.",
 		de: "Eingereichte Referenzen prüfen und moderieren.",
@@ -9587,7 +9587,7 @@ export const pageLabels = {
 	},
 	"testimonials.partialResults": {
 		en: "Some testimonial data is temporarily unavailable. This page is showing partial results.",
-		ar: "Some testimonial data is temporarily unavailable. This page is showing partial results.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بعض بيانات الإفادات غير متاحة مؤقّتًا. تعرض هذه الصفحة نتائج جزئية.",
 		es: "Algunos datos de testimonios no están disponibles temporalmente. Esta página muestra resultados parciales.",
 		fr: "Certaines données de témoignages sont temporairement indisponibles. Cette page affiche des résultats partiels.",
 		de: "Einige Referenzdaten sind vorübergehend nicht verfügbar. Diese Seite zeigt Teilergebnisse.",
@@ -9599,7 +9599,7 @@ export const pageLabels = {
 	},
 	"testimonials.savedSuccess": {
 		en: "The testimonial was updated successfully.",
-		ar: "The testimonial was updated successfully.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تم تحديث الإفادة بنجاح.",
 		es: "El testimonio se actualizó correctamente.",
 		fr: "Le témoignage a été mis à jour avec succès.",
 		de: "Die Referenz wurde erfolgreich aktualisiert.",
@@ -9611,7 +9611,7 @@ export const pageLabels = {
 	},
 	"testimonials.totalSubmitted": {
 		en: "Total submitted",
-		ar: "Total submitted", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجمالي المُرسَل",
 		es: "Total enviado",
 		fr: "Total soumis",
 		de: "Insgesamt eingereicht",
@@ -9623,7 +9623,7 @@ export const pageLabels = {
 	},
 	"testimonials.totalSubmittedDesc": {
 		en: "All testimonial submissions across statuses.",
-		ar: "All testimonial submissions across statuses.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "كل إفادات العملاء المُرسَلة عبر جميع الحالات.",
 		es: "Todas las publicaciones de testimonios en todos los estados.",
 		fr: "Toutes les soumissions de témoignages, tous statuts confondus.",
 		de: "Alle Referenzeinreichungen über alle Status hinweg.",
@@ -9635,7 +9635,7 @@ export const pageLabels = {
 	},
 	"testimonials.pendingReview": {
 		en: "Pending review",
-		ar: "Pending review", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "بانتظار المراجعة",
 		es: "Pendiente de revisión",
 		fr: "En attente d'examen",
 		de: "Prüfung ausstehend",
@@ -9647,7 +9647,7 @@ export const pageLabels = {
 	},
 	"testimonials.pendingReviewDesc": {
 		en: "Submissions awaiting a moderation decision.",
-		ar: "Submissions awaiting a moderation decision.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإفادات بانتظار قرار إشرافي.",
 		es: "Publicaciones a la espera de una decisión de moderación.",
 		fr: "Soumissions en attente d'une décision de modération.",
 		de: "Einreichungen, die auf eine Moderationsentscheidung warten.",
@@ -9659,7 +9659,7 @@ export const pageLabels = {
 	},
 	"testimonials.moderationKicker": {
 		en: "Moderation",
-		ar: "Moderation", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإشراف",
 		es: "Moderación",
 		fr: "Modération",
 		de: "Moderation",
@@ -9671,7 +9671,7 @@ export const pageLabels = {
 	},
 	"testimonials.queueHeading": {
 		en: "Testimonial Queue",
-		ar: "Testimonial Queue", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "قائمة انتظار الإفادات",
 		es: "Cola de testimonios",
 		fr: "File de témoignages",
 		de: "Referenz-Warteschlange",
@@ -9683,7 +9683,7 @@ export const pageLabels = {
 	},
 	"testimonials.tabsLabel": {
 		en: "Testimonial status tabs",
-		ar: "Testimonial status tabs", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تبويبات حالة الإفادات",
 		es: "Pestañas de estado de testimonios",
 		fr: "Onglets de statut des témoignages",
 		de: "Tabs für Referenzstatus",
@@ -9695,7 +9695,7 @@ export const pageLabels = {
 	},
 	"testimonials.tabPending": {
 		en: "Pending",
-		ar: "Pending", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "معلَّق",
 		es: "Pendientes",
 		fr: "En attente",
 		de: "Ausstehend",
@@ -9707,7 +9707,7 @@ export const pageLabels = {
 	},
 	"testimonials.tabApproved": {
 		en: "Approved",
-		ar: "Approved", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "معتمد",
 		es: "Aprobados",
 		fr: "Approuvés",
 		de: "Genehmigt",
@@ -9719,7 +9719,7 @@ export const pageLabels = {
 	},
 	"testimonials.tabFeatured": {
 		en: "Featured",
-		ar: "Featured", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مميَّز",
 		es: "Destacados",
 		fr: "À la une",
 		de: "Hervorgehoben",
@@ -9731,7 +9731,7 @@ export const pageLabels = {
 	},
 	"testimonials.emptyPending": {
 		en: "No pending testimonials.",
-		ar: "No pending testimonials.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد إفادات معلَّقة.",
 		es: "No hay testimonios pendientes.",
 		fr: "Aucun témoignage en attente.",
 		de: "Keine ausstehenden Referenzen.",
@@ -9743,7 +9743,7 @@ export const pageLabels = {
 	},
 	"testimonials.emptyApproved": {
 		en: "No approved testimonials.",
-		ar: "No approved testimonials.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد إفادات معتمَدة.",
 		es: "No hay testimonios aprobados.",
 		fr: "Aucun témoignage approuvé.",
 		de: "Keine genehmigten Referenzen.",
@@ -9755,7 +9755,7 @@ export const pageLabels = {
 	},
 	"testimonials.emptyFeatured": {
 		en: "No featured testimonials.",
-		ar: "No featured testimonials.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد إفادات مميَّزة.",
 		es: "No hay testimonios destacados.",
 		fr: "Aucun témoignage à la une.",
 		de: "Keine hervorgehobenen Referenzen.",
@@ -9767,7 +9767,7 @@ export const pageLabels = {
 	},
 	"testimonials.tableLabelPending": {
 		en: "pending testimonials",
-		ar: "pending testimonials", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إفادات معلَّقة",
 		es: "testimonios pendientes",
 		fr: "témoignages en attente",
 		de: "ausstehende Referenzen",
@@ -9779,7 +9779,7 @@ export const pageLabels = {
 	},
 	"testimonials.tableLabelApproved": {
 		en: "approved testimonials",
-		ar: "approved testimonials", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إفادات معتمَدة",
 		es: "testimonios aprobados",
 		fr: "témoignages approuvés",
 		de: "genehmigte Referenzen",
@@ -9791,7 +9791,7 @@ export const pageLabels = {
 	},
 	"testimonials.tableLabelFeatured": {
 		en: "featured testimonials",
-		ar: "featured testimonials", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إفادات مميَّزة",
 		es: "testimonios destacados",
 		fr: "témoignages à la une",
 		de: "hervorgehobene Referenzen",
@@ -9803,7 +9803,7 @@ export const pageLabels = {
 	},
 	"testimonials.colName": {
 		en: "Name",
-		ar: "Name", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الاسم",
 		es: "Nombre",
 		fr: "Nom",
 		de: "Name",
@@ -9815,7 +9815,7 @@ export const pageLabels = {
 	},
 	"testimonials.colCompany": {
 		en: "Company",
-		ar: "Company", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الشركة",
 		es: "Empresa",
 		fr: "Entreprise",
 		de: "Unternehmen",
@@ -9827,7 +9827,7 @@ export const pageLabels = {
 	},
 	"testimonials.colRole": {
 		en: "Role",
-		ar: "Role", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الدور",
 		es: "Cargo",
 		fr: "Rôle",
 		de: "Rolle",
@@ -9839,7 +9839,7 @@ export const pageLabels = {
 	},
 	"testimonials.colSpecificResult": {
 		en: "Specific Result",
-		ar: "Specific Result", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نتيجة محدّدة",
 		es: "Resultado específico",
 		fr: "Résultat spécifique",
 		de: "Konkretes Ergebnis",
@@ -9851,7 +9851,7 @@ export const pageLabels = {
 	},
 	"testimonials.colConsent": {
 		en: "Consent",
-		ar: "Consent", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الموافقة",
 		es: "Consentimiento",
 		fr: "Consentement",
 		de: "Einwilligung",
@@ -9863,7 +9863,7 @@ export const pageLabels = {
 	},
 	"testimonials.colSource": {
 		en: "Source",
-		ar: "Source", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "المصدر",
 		es: "Fuente",
 		fr: "Source",
 		de: "Quelle",
@@ -9875,7 +9875,7 @@ export const pageLabels = {
 	},
 	"testimonials.colSubmitted": {
 		en: "Submitted",
-		ar: "Submitted", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "مُرسَل",
 		es: "Enviado",
 		fr: "Soumis",
 		de: "Eingereicht",
@@ -9887,7 +9887,7 @@ export const pageLabels = {
 	},
 	"testimonials.colAction": {
 		en: "Action",
-		ar: "Action", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إجراء",
 		es: "Acción",
 		fr: "Action",
 		de: "Aktion",
@@ -9899,7 +9899,7 @@ export const pageLabels = {
 	},
 	"testimonials.consentYes": {
 		en: "Yes",
-		ar: "Yes", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "نعم",
 		es: "Sí",
 		fr: "Oui",
 		de: "Ja",
@@ -9911,7 +9911,7 @@ export const pageLabels = {
 	},
 	"testimonials.consentNo": {
 		en: "No",
-		ar: "No", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا",
 		es: "No",
 		fr: "Non",
 		de: "Nein",
@@ -9923,7 +9923,7 @@ export const pageLabels = {
 	},
 	"testimonials.approve": {
 		en: "Approve",
-		ar: "Approve", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "اعتماد",
 		es: "Aprobar",
 		fr: "Approuver",
 		de: "Genehmigen",
@@ -9935,7 +9935,7 @@ export const pageLabels = {
 	},
 	"testimonials.reject": {
 		en: "Reject",
-		ar: "Reject", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "رفض",
 		es: "Rechazar",
 		fr: "Rejeter",
 		de: "Ablehnen",
@@ -9947,7 +9947,7 @@ export const pageLabels = {
 	},
 	"testimonials.feature": {
 		en: "Feature",
-		ar: "Feature", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تمييز",
 		es: "Destacar",
 		fr: "Mettre à la une",
 		de: "Hervorheben",
@@ -9959,7 +9959,7 @@ export const pageLabels = {
 	},
 	"testimonials.unfeature": {
 		en: "Unfeature",
-		ar: "Unfeature", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "إلغاء التمييز",
 		es: "Quitar destacado",
 		fr: "Retirer de la une",
 		de: "Hervorhebung entfernen",
@@ -9971,7 +9971,7 @@ export const pageLabels = {
 	},
 	"footer.reportIssue": {
 		en: "Report issue or suggest feature",
-		ar: "Report issue or suggest feature", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "الإبلاغ عن مشكلة أو اقتراح ميزة",
 		es: "Informar problema o sugerir función",
 		fr: "Signaler un problème ou suggérer une fonctionnalité",
 		de: "Problem melden oder Funktion vorschlagen",
@@ -9983,7 +9983,7 @@ export const pageLabels = {
 	},
 	"footer.docs": {
 		en: "Documentation",
-		ar: "Documentation", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "التوثيق",
 		es: "Documentación",
 		fr: "Documentation",
 		de: "Dokumentation",
@@ -9996,7 +9996,7 @@ export const pageLabels = {
 	"access.title": { en: "Access" },
 	"access.description": {
 		en: "Manage roles, role assignments, direct user grants, and view your effective permissions.",
-		ar: "Manage roles, role assignments, direct user grants, and view your effective permissions.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "أدِر الأدوار وإسناداتها والصلاحيات المباشرة للمستخدمين، واطّلع على صلاحياتك الفعّالة.",
 	},
 	"access.tabUsers": { en: "Users" },
 	"access.tabRoles": { en: "Roles" },
@@ -10004,7 +10004,7 @@ export const pageLabels = {
 	"access.usersHeading": { en: "User access" },
 	"access.usersDescription": {
 		en: "Assign roles, view direct grants, and ensure at least one break-glass admin remains.",
-		ar: "Assign roles, view direct grants, and ensure at least one break-glass admin remains.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "عيِّن الأدوار، واطّلع على الصلاحيات المباشرة، وتأكّد من بقاء مسؤول طوارئ واحد على الأقل.",
 	},
 	"access.usersColumnUser": { en: "User" },
 	"access.usersColumnRoles": { en: "Roles" },
@@ -10014,14 +10014,14 @@ export const pageLabels = {
 	"access.usersDirectGrantsBadge": { en: "Direct grants" },
 	"access.lastAdminWarning": {
 		en: "Only one active admin remains. Grant another user the Admin flag before changing this one to keep break-glass access.",
-		ar: "Only one active admin remains. Grant another user the Admin flag before changing this one to keep break-glass access.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'لم يتبقَّ سوى مسؤول نشط واحد. امنح علم "الإدارة" لمستخدم آخر قبل تغيير هذا للحفاظ على وصول الطوارئ.',
 	},
 	"access.assignRoleSubmit": { en: "Assign" },
 	"access.revokeRoleSubmit": { en: "Revoke" },
 	"access.directGrantsHeading": { en: "Direct grants" },
 	"access.directGrantsDescription": {
 		en: "Per-user policy overrides outside the role bundles. Use sparingly — they create permission sprawl that's harder to audit.",
-		ar: "Per-user policy overrides outside the role bundles. Use sparingly — they create permission sprawl that's harder to audit.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "تجاوزات السياسات لكل مستخدم خارج حزم الأدوار. استخدمها باعتدال — فهي تخلق توسّعًا في الصلاحيات يصعب تدقيقه.",
 	},
 	"access.directGrantActionLabel": { en: "Action" },
 	"access.directGrantEffectLabel": { en: "Effect" },
@@ -10032,7 +10032,7 @@ export const pageLabels = {
 	"access.rolesHeading": { en: "Roles" },
 	"access.rolesDescription": {
 		en: "Roles bundle policies. Assign roles to users on the Users tab; refine policies here.",
-		ar: "Roles bundle policies. Assign roles to users on the Users tab; refine policies here.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'تجمع الأدوار السياسات. عيِّن الأدوار للمستخدمين في تبويب "المستخدمون" واضبط السياسات هنا.',
 	},
 	"access.rolesCreateHeading": { en: "Create role" },
 	"access.rolesNameLabel": { en: "Name" },
@@ -10050,11 +10050,11 @@ export const pageLabels = {
 	"access.myPermissionsHeading": { en: "My permissions" },
 	"access.myPermissionsDescription": {
 		en: "Effective policies for your subject — union of role bundles plus direct grants. Admin bypasses evaluation but the snapshot is shown for transparency.",
-		ar: "Effective policies for your subject — union of role bundles plus direct grants. Admin bypasses evaluation but the snapshot is shown for transparency.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: 'السياسات الفعّالة لموضوعك — اتحاد حزم الأدوار مع الصلاحيات المباشرة. تجاوز "الإدارة" التقييم لكن تُعرض اللقطة للشفافية.',
 	},
 	"access.myPermissionsEmpty": {
 		en: "No policies attached to your subject.",
-		ar: "No policies attached to your subject.", // TODO(i18n-ar): native-speaker review (issue #76)
+		ar: "لا توجد سياسات مرتبطة بموضوعك.",
 	},
 	"access.myPermissionsActionColumn": { en: "Action" },
 	"access.myPermissionsEffectColumn": { en: "Effect" },

--- a/tooling/e2e/admin-i18n-no-english-leak.spec.ts
+++ b/tooling/e2e/admin-i18n-no-english-leak.spec.ts
@@ -73,14 +73,15 @@ async function snapshotChrome(page: import("@playwright/test").Page): Promise<Ch
 	});
 }
 
-// Locales tested at runtime: te catches non-Latin script leaks. Adding ar
-// here will be possible once the AR translation pass lands (tracked in a
-// follow-up issue) — the existing label catalog falls back to EN for
-// AR until then, which would cause every chrome assertion to fail.
+// Locales tested at runtime: te catches non-Latin script leaks and exercises
+// LTR-only chrome. ar covers the RTL case and additionally exercises the
+// full Arabic translation pass (admin-labels.ts + admin-page-labels.ts).
+// The seed Arabic translations carry a follow-up review under issue #76 —
+// any wording fix lands without changing keys, so this gate remains stable.
 //
 // The full coverage gate (every locale × every key in the catalog) is
 // enforced statically by tooling/scripts/audit-admin-i18n-leaks.ts.
-const NON_EN_LOCALES = ["te"] as const;
+const NON_EN_LOCALES = ["te", "ar"] as const;
 
 test.describe("Admin i18n: chrome must change between English and target locale", () => {
 	for (const route of ADMIN_ROUTES) {
@@ -104,16 +105,19 @@ test.describe("Admin i18n: chrome must change between English and target locale"
 				const te = await snapshotChrome(page);
 
 				expect(en.h1.length, `${route}: missing <h1> in English render`).toBeGreaterThan(0);
-				expect(te.h1.length, `${route}: missing <h1> in Telugu render`).toBeGreaterThan(0);
+				expect(
+					te.h1.length,
+					`${route}: missing <h1> in ${locale.toUpperCase()} render`,
+				).toBeGreaterThan(0);
 
 				expect(
 					te.h1,
-					`${route}: <h1> "${te.h1}" did not change between EN and TE — likely hardcoded English string instead of t(...)`,
+					`${route}: <h1> "${te.h1}" did not change between EN and ${locale.toUpperCase()} — likely hardcoded English string instead of t(...)`,
 				).not.toBe(en.h1);
 
 				expect(
 					te.title,
-					`${route}: <title> did not change between EN and TE — document title is not localised`,
+					`${route}: <title> did not change between EN and ${locale.toUpperCase()} — document title is not localised`,
 				).not.toBe(en.title);
 
 				// Navigation labels are shared chrome rendered by AdminLayout; if any of them
@@ -122,7 +126,7 @@ test.describe("Admin i18n: chrome must change between English and target locale"
 				const teNav = te.navLabels.join(" | ");
 				expect(
 					teNav,
-					`${route}: navigation labels did not change between EN and TE\nEN: ${enNav}\nTE: ${teNav}`,
+					`${route}: navigation labels did not change between EN and ${locale.toUpperCase()}\nEN: ${enNav}\nTE: ${teNav}`,
 				).not.toBe(enNav);
 
 				// Per-page <h2> section headings — each English heading must differ from
@@ -140,7 +144,7 @@ test.describe("Admin i18n: chrome must change between English and target locale"
 					if (TECH_IDENTIFIER.test(enH)) continue;
 					expect(
 						teH,
-						`${route}: <main> <h2>[${i}] "${teH}" did not change between EN and TE — likely hardcoded English string instead of t(...)`,
+						`${route}: <main> <h2>[${i}] "${teH}" did not change between EN and ${locale.toUpperCase()} — likely hardcoded English string instead of t(...)`,
 					).not.toBe(enH);
 				}
 

--- a/tooling/stryker/baseline-scores.json
+++ b/tooling/stryker/baseline-scores.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-18T16:04:02.334Z",
+  "updatedAt": "2026-05-19T07:59:09.975Z",
   "scores": {
     "packages/astropress/src/adapters/adapter-record-helpers.ts": {
       "score": 100,
@@ -935,7 +935,7 @@
     },
     "packages/astropress/src/admin-page-labels.ts": {
       "score": 100,
-      "hash": "207e474625efada2049a5fecbb35018851bc40fc"
+      "hash": "215814754bb3a55b46d71a3772d0e920937a4f4d"
     },
     "packages/astropress/src/admin-page-models-access.ts": {
       "score": 100,


### PR DESCRIPTION
## Summary
Two issues, one PR.

### Issue #72 — Arabic localisation complete

* `packages/astropress/src/admin-page-labels.ts` — 835 entries that previously carried `TODO(i18n-ar): native-speaker review (issue #76)` markers are now translated to Modern Standard Arabic. **0 TODOs remain.**
* `tooling/e2e/admin-i18n-no-english-leak.spec.ts` — `NON_EN_LOCALES` now includes `ar` alongside `te`. The chrome-snapshot comparison runs over every gated admin route (h1, title, nav labels, h2 section headings, support-card labels) in AR end-to-end. Error messages are templated on the loop's `${locale}` so the same scenario emits route+locale-aware diagnostics.
* `admin-rtl.test.ts` (already landed in PR #98) already covers `dir="rtl"` plumbing across `AdminLayout` and the three pre-auth entry pages; this PR doesn't touch it.

The Arabic seed translations are MSA-faithful but issue #76 still tracks a native-speaker review pass — that's wording polish that lands without changing keys, so the no-english-leak gate stays stable.

### Issue #28 — clear intake paths

* `.github/ISSUE_TEMPLATE/language_request.md` — new template for locale requests; covers script direction, native-speaker availability, RTL plumbing dependency.
* `.github/ISSUE_TEMPLATE/integration_request.md` — new template for external tools (analytics, email, A/B testing, donations, webhooks), distinct from `adapter_support.md` (now scoped to hosting providers / data services).
* `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; surfaces GitHub Discussions for open-ended threads.
* `README.md` — "Requesting new platforms, integrations, or languages" table replaces the vague "add an issue" line; links every template by category.
* `CONTRIBUTING.md` — new "Requesting and contributing providers" section covers adapters, integrations, and locales with the audit gate that enforces each.

## Test plan
- [x] `bun run vitest run tests/admin-rtl.test.ts tests/public-site-integration-rtl.test.ts` — 16/16 pass
- [x] `bun run audit:admin-i18n-leaks` — 73 .astro files clean
- [x] Pre-push gates: 13 min, all green
- [ ] PR checks
- [ ] PR-merge-ref CodeQL

Closes #72. Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)