### PR TITLE
fix(ci): balance Stryker shards; webhook REST validation parity (#141)

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -48,17 +48,21 @@ jobs:
     # run from showing up as a red workflow when the cache simply needs
     # more time on a cold start.
     continue-on-error: true
-    # Cold full-suite (unsharded) historically ran ~4h11m. Splitting into
-    # two alphabetic shards drops the wall to ~2h15m each; the ceiling
-    # below covers drift + extended-coverage from new source files.
-    timeout-minutes: 480
+    # GitHub HARD-caps a hosted job at 6h regardless of this value, so the
+    # old 480 (8h) could never take effect — a cold shard that needed >6h was
+    # killed as "cancelled" (not a step failure), which `continue-on-error`
+    # cannot absorb. Keep this below the 6h ceiling so the job ends on its own
+    # terms; the N=4 balanced round-robin (see stryker.config.mjs) keeps even
+    # a fully-cold shard around ~1–1.5h, far under this.
+    timeout-minutes: 330
     strategy:
       fail-fast: false
       matrix:
-        # Each shard mutates a roughly-equal half of src/ (a–m, n–z) with
-        # its own incremental cache file on the `stryker-state` branch.
-        # Lock contention is avoided because each shard uses lock-<shard>.json.
-        shard: [a, b]
+        # Each shard mutates a balanced 1/N round-robin slice of src/ (see
+        # stryker.config.mjs) with its own incremental cache file on the
+        # `stryker-state` branch. Lock contention is avoided because each
+        # shard uses lock-<shard>.json.
+        shard: [a, b, c, d]
     permissions:
       # `run-mutants-shared` reads from and pushes to the `stryker-state`
       # branch via the git refs API; the default GITHUB_TOKEN needs explicit

--- a/bun.lock
+++ b/bun.lock
@@ -146,6 +146,7 @@
     "hono": "^4.12.18",
     "ip-address": "^10.2.0",
     "postcss": "^8.5.10",
+    "qs": "^6.15.2",
     "vite": "^7.3.2",
     "yaml": "^2.8.3",
   },
@@ -1536,7 +1537,7 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -3,7 +3,7 @@
 Auto-generated from TypeScript source via the TypeScript compiler API.
 Run `bun run docs:api` to regenerate.
 
-Generated: 2026-05-18
+Generated: 2026-05-24
 
 ---
 
@@ -1506,6 +1506,16 @@ function isAstropressLocalRuntimeModuleRequest(id: string, localRuntimeModulesPa
 function createAstropressVitestLocalRuntimePlugins(localRuntimeModulesPath: string): AstropressVitestPlugin[]
 ```
 
+#### `isWebhookEvent`
+```ts
+function isWebhookEvent(value: unknown): boolean
+```
+
+#### `validateWebhookCreateInput`
+```ts
+function validateWebhookCreateInput(input: { url: unknown; events: unknown; }): WebhookValidationResult
+```
+
 ### Types & Interfaces
 
 - `interface AccessContext`
@@ -1747,6 +1757,8 @@ function createAstropressVitestLocalRuntimePlugins(localRuntimeModulesPath: stri
 - `type AstropressVitePlugin`
 - `type AstropressViteRuntimeAliasOptions`
 - `type AstropressVitestPlugin`
+- `interface WebhookCreateInput`
+- `type WebhookValidationResult`
 
 ### Constants & Re-exports
 
@@ -1783,6 +1795,7 @@ function createAstropressVitestLocalRuntimePlugins(localRuntimeModulesPath: stri
 - `const placeholderAdapter: NewsletterAdapter`
 - `const defaultSiteSettings: SiteSettings`
 - `const translationStates: readonly ["not_started", "partial", "fallback_en", "translated", "reviewed", "published"]`
+- `const WEBHOOK_EVENTS: readonly WebhookEvent[]`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
 		"ip-address": "^10.2.0",
 		"fast-uri": "^3.1.2",
 		"devalue": "^5.8.1",
-		"brace-expansion": "^5.0.6"
+		"brace-expansion": "^5.0.6",
+		"qs": "^6.15.2"
 	},
 	"browserslist": [
 		"Chrome >= 108",

--- a/packages/astropress/index.ts
+++ b/packages/astropress/index.ts
@@ -829,3 +829,14 @@ export {
 } from "./src/vite-runtime-alias";
 export type { AstropressVitestPlugin } from "./src/vitest-runtime-alias";
 export { createAstropressVitestLocalRuntimePlugins } from "./src/vitest-runtime-alias";
+// Shared webhook creation validation — used by both the admin form action
+// and the REST API so the two paths cannot drift (issue #141).
+export type {
+	WebhookCreateInput,
+	WebhookValidationResult,
+} from "./src/webhook-validation.js";
+export {
+	isWebhookEvent,
+	validateWebhookCreateInput,
+} from "./src/webhook-validation.js";
+export { WEBHOOK_EVENTS } from "./src/webhook-validation-data.js";

--- a/packages/astropress/pages/ap-admin/actions/webhook-create.ts
+++ b/packages/astropress/pages/ap-admin/actions/webhook-create.ts
@@ -1,37 +1,22 @@
-import { withAdminFormAction } from "@astropress-diy/astropress";
+import { validateWebhookCreateInput, withAdminFormAction } from "@astropress-diy/astropress";
 import { loadLocalAdminStore } from "@astropress-diy/astropress/local-runtime-modules.js";
-import type { WebhookEvent } from "@astropress-diy/astropress/platform-contracts.js";
 import type { APIRoute } from "astro";
-
-const VALID_EVENTS: WebhookEvent[] = [
-	"content.published",
-	"content.updated",
-	"content.deleted",
-	"media.uploaded",
-	"media.deleted",
-];
 
 export const POST: APIRoute = async (context) =>
 	withAdminFormAction(
 		context,
 		{ failurePath: "/ap-admin/webhooks", requireAdmin: true },
 		async ({ formData, redirect, fail }) => {
-			const url = String(formData.get("url") ?? "").trim();
-			if (!url) return fail("Webhook URL is required.");
-			if (!url.startsWith("https://") && !url.startsWith("http://"))
-				return fail("URL must start with http:// or https://");
-
-			const eventValues = formData.getAll("events").map(String) as WebhookEvent[];
-			const events = eventValues.filter((e) => VALID_EVENTS.includes(e));
-			if (events.length === 0) return fail("At least one event is required.");
+			const validation = validateWebhookCreateInput({
+				url: formData.get("url"),
+				events: formData.getAll("events").map(String),
+			});
+			if (!validation.ok) return fail(validation.error);
 
 			const store = await loadLocalAdminStore();
 			if (!store.webhooks) return fail("Webhook store is not available.");
 
-			const { record, verification } = await store.webhooks.create({
-				url,
-				events,
-			});
+			const { record, verification } = await store.webhooks.create(validation.value);
 			return redirect(
 				`/ap-admin/webhooks?created=1&webhookId=${encodeURIComponent(record.id)}&algorithm=${encodeURIComponent(verification.algorithm)}&publicKey=${encodeURIComponent(verification.publicKey)}`,
 			);

--- a/packages/astropress/pages/ap-api/v1/webhooks.ts
+++ b/packages/astropress/pages/ap-api/v1/webhooks.ts
@@ -1,4 +1,4 @@
-import { getCmsConfig } from "@astropress-diy/astropress";
+import { getCmsConfig, validateWebhookCreateInput } from "@astropress-diy/astropress";
 import {
 	apiErrors,
 	jsonOk,
@@ -6,7 +6,6 @@ import {
 	withApiRequest,
 } from "@astropress-diy/astropress/api-middleware.js";
 import { loadLocalAdminStore } from "@astropress-diy/astropress/local-runtime-modules.js";
-import type { WebhookEvent } from "@astropress-diy/astropress/platform-contracts.js";
 import type { APIRoute } from "astro";
 
 type LocalAdminStore = Awaited<ReturnType<typeof loadLocalAdminStore>>;
@@ -71,16 +70,13 @@ export const POST: APIRoute = async (context) => {
 				return apiErrors.validationError("Request body must be valid JSON.");
 			}
 
-			const url = String(body.url ?? "").trim();
-			if (!url) return apiErrors.validationError("url is required.");
-
-			const events = Array.isArray(body.events) ? (body.events as WebhookEvent[]) : [];
-			if (events.length === 0) return apiErrors.validationError("At least one event is required.");
-
-			const { record, verification } = await store.webhooks.create({
-				url,
-				events,
+			const validation = validateWebhookCreateInput({
+				url: body.url,
+				events: body.events,
 			});
+			if (!validation.ok) return apiErrors.validationError(validation.error);
+
+			const { record, verification } = await store.webhooks.create(validation.value);
 			return jsonOk({ record, verification }, 201);
 		},
 	);

--- a/packages/astropress/src/webhook-validation-data.ts
+++ b/packages/astropress/src/webhook-validation-data.ts
@@ -1,0 +1,19 @@
+// stryker-disable-file: data-only — canonical webhook-event allowlist. The
+// values carry no behavioural contract of their own; the validator that
+// consumes them (webhook-validation.ts) is mutation-tested at ≥95%. Splitting
+// the constant out keeps a static-mutant on this array from surviving under
+// the vitest worker-cache (see CLAUDE.md "module-level constants").
+import type { WebhookEvent } from "./platform-contracts";
+
+/**
+ * The single source of truth for which webhook events callers may register.
+ * Both the admin form action and the REST API validate against this list, so
+ * the two creation paths can never drift apart on what counts as a valid event.
+ */
+export const WEBHOOK_EVENTS: readonly WebhookEvent[] = [
+	"content.published",
+	"content.updated",
+	"content.deleted",
+	"media.uploaded",
+	"media.deleted",
+];

--- a/packages/astropress/src/webhook-validation.ts
+++ b/packages/astropress/src/webhook-validation.ts
@@ -1,0 +1,62 @@
+import type { WebhookEvent } from "./platform-contracts";
+import { WEBHOOK_EVENTS } from "./webhook-validation-data";
+
+/**
+ * Shared validation for webhook creation. Both the admin form action
+ * (`pages/ap-admin/actions/webhook-create.ts`) and the token-authenticated
+ * REST API (`pages/ap-api/v1/webhooks.ts`) run callers' input through this
+ * one layer, so a `webhooks:manage` token can never persist a webhook the
+ * admin UI would reject (issue #141). The stored URL is later handed to
+ * `fetch()` by the dispatcher, so the scheme check here is the gate that
+ * keeps arbitrary callback targets out of the store.
+ */
+
+export interface WebhookCreateInput {
+	url: string;
+	events: WebhookEvent[];
+}
+
+export type WebhookValidationResult =
+	| { ok: true; value: WebhookCreateInput }
+	| { ok: false; error: string };
+
+/** Narrowing guard for a single event name against the canonical allowlist. */
+export function isWebhookEvent(value: unknown): value is WebhookEvent {
+	return typeof value === "string" && (WEBHOOK_EVENTS as readonly string[]).includes(value);
+}
+
+/** Human-readable allowlist for error messages — derived, never hand-typed. */
+function supportedEventsList(): string {
+	return WEBHOOK_EVENTS.join(", ");
+}
+
+/**
+ * Validate raw, untrusted webhook-creation input. Returns the normalised
+ * `{ url, events }` on success or a single user-facing error string.
+ *
+ * Invalid/unsupported event names are *rejected*, not silently dropped: a
+ * caller asking for an event we do not support is a mistake worth surfacing,
+ * and silently persisting a partial subset hides it. The error never echoes
+ * the caller's rejected strings back — it lists the supported events instead,
+ * so nothing user-controlled is reflected into the admin page or API body.
+ */
+export function validateWebhookCreateInput(input: {
+	url: unknown;
+	events: unknown;
+}): WebhookValidationResult {
+	const url = typeof input.url === "string" ? input.url.trim() : "";
+	if (!url) return { ok: false, error: "Webhook URL is required." };
+	if (!url.startsWith("https://") && !url.startsWith("http://"))
+		return { ok: false, error: "URL must start with http:// or https://" };
+
+	const rawEvents = Array.isArray(input.events) ? input.events : [];
+	if (rawEvents.length === 0) return { ok: false, error: "At least one event is required." };
+
+	if (!rawEvents.every(isWebhookEvent))
+		return {
+			ok: false,
+			error: `One or more events are not supported. Valid events: ${supportedEventsList()}.`,
+		};
+
+	return { ok: true, value: { url, events: rawEvents as WebhookEvent[] } };
+}

--- a/packages/astropress/tests/api-endpoints.test.ts
+++ b/packages/astropress/tests/api-endpoints.test.ts
@@ -481,6 +481,59 @@ describe("GET /ap-api/v1/webhooks + POST /ap-api/v1/webhooks", () => {
 		expect(body.verification.algorithm).toBe("ML-DSA-65");
 		expect(body.verification.publicKey.length).toBeGreaterThan(0);
 	});
+
+	// Parity with the admin form action (issue #141): the token-authenticated
+	// REST path must reject the same input the admin UI would, and must never
+	// persist an unvalidated webhook target/event.
+	it("POST rejects a non-http(s) url with 422 and does not persist", async () => {
+		mocks.webhooksCreate.mockClear();
+		const res = await webhooksPOST(
+			ctx(
+				req("POST", "/ap-api/v1/webhooks", {
+					token: webhooksManageToken,
+					body: { url: "ftp://example.com/hook", events: ["content.published"] },
+				}),
+			),
+		);
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { error: string; code: string };
+		expect(body.code).toBe("validation_error");
+		expect(body.error).toContain("http://");
+		expect(mocks.webhooksCreate).not.toHaveBeenCalled();
+	});
+
+	it("POST rejects an unsupported event name with 422 and does not persist", async () => {
+		mocks.webhooksCreate.mockClear();
+		const res = await webhooksPOST(
+			ctx(
+				req("POST", "/ap-api/v1/webhooks", {
+					token: webhooksManageToken,
+					body: {
+						url: "https://example.com/hook",
+						events: ["content.published", "content.created"],
+					},
+				}),
+			),
+		);
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("not supported");
+		expect(mocks.webhooksCreate).not.toHaveBeenCalled();
+	});
+
+	it("POST rejects an empty events array with 422 and does not persist", async () => {
+		mocks.webhooksCreate.mockClear();
+		const res = await webhooksPOST(
+			ctx(
+				req("POST", "/ap-api/v1/webhooks", {
+					token: webhooksManageToken,
+					body: { url: "https://example.com/hook", events: [] },
+				}),
+			),
+		);
+		expect(res.status).toBe(422);
+		expect(mocks.webhooksCreate).not.toHaveBeenCalled();
+	});
 });
 
 // ─── GET /ap-api/v1/openapi.json ─────────────────────────────────────────────

--- a/packages/astropress/tests/webhook-validation.test.ts
+++ b/packages/astropress/tests/webhook-validation.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isWebhookEvent, validateWebhookCreateInput } from "../src/webhook-validation";
+import { WEBHOOK_EVENTS } from "../src/webhook-validation-data";
+
+// For the admin-action parity block below: keep the real shared validator
+// (the whole point of issue #141 is that the admin action and the REST API
+// run the *same* validation), but replace the auth/session guard with a thin
+// shim that hands the handler a real FormData and records fail()/redirect().
+// These vi.mock calls are hoisted above the imports; they only intercept the
+// barrel import used by the page module, not the direct ../src imports above.
+vi.mock("@astropress-diy/astropress", async (importActual) => {
+	const actual = await importActual<typeof import("@astropress-diy/astropress")>();
+	return {
+		...actual,
+		withAdminFormAction: async (
+			context: { request: Request },
+			options: { failurePath: string },
+			run: (action: {
+				formData: FormData;
+				fail: (message: string) => Response;
+				redirect: (url: string) => Response;
+			}) => Promise<Response> | Response,
+		) =>
+			run({
+				formData: await context.request.formData(),
+				fail: (message: string) =>
+					new Response(null, {
+						status: 303,
+						headers: { location: `${options.failurePath}?error=${encodeURIComponent(message)}` },
+					}),
+				redirect: (url: string) => new Response(null, { status: 303, headers: { location: url } }),
+			}),
+	};
+});
+
+const mockCreate = vi.fn();
+vi.mock("@astropress-diy/astropress/local-runtime-modules.js", () => ({
+	loadLocalAdminStore: vi.fn(async () => ({ webhooks: { create: mockCreate } })),
+}));
+
+import { POST as webhookCreatePOST } from "../pages/ap-admin/actions/webhook-create.js";
+
+describe("isWebhookEvent", () => {
+	it("accepts every name in the canonical allowlist", () => {
+		for (const event of WEBHOOK_EVENTS) {
+			expect(isWebhookEvent(event)).toBe(true);
+		}
+	});
+
+	it("rejects unknown event names", () => {
+		expect(isWebhookEvent("content.created")).toBe(false);
+		expect(isWebhookEvent("content.published.extra")).toBe(false);
+		expect(isWebhookEvent("")).toBe(false);
+	});
+
+	it("rejects non-string values", () => {
+		expect(isWebhookEvent(undefined)).toBe(false);
+		expect(isWebhookEvent(null)).toBe(false);
+		expect(isWebhookEvent(42)).toBe(false);
+		expect(isWebhookEvent(["content.published"])).toBe(false);
+		expect(isWebhookEvent({ event: "content.published" })).toBe(false);
+	});
+});
+
+describe("validateWebhookCreateInput — URL", () => {
+	it("rejects a missing url", () => {
+		const result = validateWebhookCreateInput({ url: undefined, events: ["content.published"] });
+		expect(result).toEqual({ ok: false, error: "Webhook URL is required." });
+	});
+
+	it("rejects an empty / whitespace-only url", () => {
+		expect(validateWebhookCreateInput({ url: "", events: ["content.published"] }).ok).toBe(false);
+		expect(validateWebhookCreateInput({ url: "   ", events: ["content.published"] }).ok).toBe(
+			false,
+		);
+	});
+
+	it("rejects a non-string url", () => {
+		const result = validateWebhookCreateInput({ url: 123, events: ["content.published"] });
+		expect(result).toEqual({ ok: false, error: "Webhook URL is required." });
+	});
+
+	it("rejects URLs that are not http(s)", () => {
+		for (const url of [
+			"ftp://example.com/hook",
+			"javascript:alert(1)",
+			"file:///etc/passwd",
+			"example.com/hook",
+			"//example.com/hook",
+		]) {
+			const result = validateWebhookCreateInput({ url, events: ["content.published"] });
+			expect(result).toEqual({
+				ok: false,
+				error: "URL must start with http:// or https://",
+			});
+		}
+	});
+
+	it("accepts http and https URLs and trims surrounding whitespace", () => {
+		const result = validateWebhookCreateInput({
+			url: "  https://example.com/hook  ",
+			events: ["content.published"],
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.value.url).toBe("https://example.com/hook");
+
+		expect(
+			validateWebhookCreateInput({ url: "http://example.com", events: ["media.deleted"] }).ok,
+		).toBe(true);
+	});
+});
+
+describe("validateWebhookCreateInput — events", () => {
+	it("rejects a missing or non-array events field", () => {
+		expect(validateWebhookCreateInput({ url: "https://example.com", events: undefined })).toEqual({
+			ok: false,
+			error: "At least one event is required.",
+		});
+		expect(
+			validateWebhookCreateInput({ url: "https://example.com", events: "content.published" }),
+		).toEqual({ ok: false, error: "At least one event is required." });
+	});
+
+	it("rejects an empty events array", () => {
+		expect(validateWebhookCreateInput({ url: "https://example.com", events: [] })).toEqual({
+			ok: false,
+			error: "At least one event is required.",
+		});
+	});
+
+	it("rejects an unsupported event name rather than silently dropping it", () => {
+		const result = validateWebhookCreateInput({
+			url: "https://example.com",
+			events: ["content.published", "content.created"],
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("not supported");
+			// The supported list is surfaced, comma-separated; the rejected
+			// (attacker-controlled) string is never echoed back.
+			expect(result.error).toContain("content.published, content.updated");
+			expect(result.error).not.toContain("content.created");
+		}
+	});
+
+	it("rejects when every event is unsupported", () => {
+		const result = validateWebhookCreateInput({
+			url: "https://example.com",
+			events: ["bogus.event"],
+		});
+		expect(result.ok).toBe(false);
+	});
+
+	it("accepts the full canonical event set", () => {
+		const result = validateWebhookCreateInput({
+			url: "https://example.com/hook",
+			events: [...WEBHOOK_EVENTS],
+		});
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.value.events).toEqual([...WEBHOOK_EVENTS]);
+	});
+});
+
+// Parity proof: the admin form action (pages/ap-admin/actions/webhook-create)
+// must reject exactly what the REST API rejects, because both now delegate to
+// the shared validator above. The REST side is covered in api-endpoints.test.ts.
+describe("POST /ap-admin/actions/webhook-create — validation parity", () => {
+	function actionRequest(fields: { url?: string; events?: string[] }): Request {
+		const fd = new FormData();
+		if (fields.url !== undefined) fd.set("url", fields.url);
+		for (const event of fields.events ?? []) fd.append("events", event);
+		return new Request("https://example.com/ap-admin/actions/webhook-create", {
+			method: "POST",
+			body: fd,
+		});
+	}
+
+	function callAction(fields: { url?: string; events?: string[] }) {
+		return webhookCreatePOST({
+			request: actionRequest(fields),
+		} as Parameters<typeof webhookCreatePOST>[0]);
+	}
+
+	function errorMessage(res: Response): string | null {
+		const location = res.headers.get("location") ?? "";
+		const query = location.split("?")[1] ?? "";
+		return new URLSearchParams(query).get("error");
+	}
+
+	beforeEach(() => {
+		mockCreate.mockReset();
+		mockCreate.mockResolvedValue({
+			record: { id: "wh-1" },
+			verification: { algorithm: "ML-DSA-65", publicKey: "k" },
+		});
+	});
+
+	it("rejects a non-http(s) url and does not persist", async () => {
+		const res = await callAction({ url: "ftp://example.com/hook", events: ["content.published"] });
+		expect(errorMessage(res)).toBe("URL must start with http:// or https://");
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unsupported event name and does not persist", async () => {
+		const res = await callAction({
+			url: "https://example.com/hook",
+			events: ["content.published", "content.created"],
+		});
+		expect(errorMessage(res)).toContain("not supported");
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	it("rejects when no events are selected and does not persist", async () => {
+		const res = await callAction({ url: "https://example.com/hook", events: [] });
+		expect(errorMessage(res)).toBe("At least one event is required.");
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	it("creates and redirects with verification metadata for valid input", async () => {
+		const res = await callAction({
+			url: "https://example.com/hook",
+			events: ["content.published", "media.uploaded"],
+		});
+		expect(mockCreate).toHaveBeenCalledWith({
+			url: "https://example.com/hook",
+			events: ["content.published", "media.uploaded"],
+		});
+		const location = res.headers.get("location") ?? "";
+		expect(location).toContain("created=1");
+		expect(location).toContain("algorithm=ML-DSA-65");
+	});
+});

--- a/tooling/stryker/baseline-scores.json
+++ b/tooling/stryker/baseline-scores.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-19T07:59:09.975Z",
+  "updatedAt": "2026-05-24T00:00:00.000Z",
   "scores": {
     "packages/astropress/src/adapters/adapter-record-helpers.ts": {
       "score": 100,
@@ -1108,6 +1108,10 @@
     "packages/astropress/src/sqlite-runtime/integrations-d1.ts": {
       "score": 100,
       "hash": "c24a66b9d46e9508985863320cb13f989e6cb31a"
+    },
+    "packages/astropress/src/webhook-validation.ts": {
+      "score": 96.07843137254902,
+      "hash": "5dc1bbe95eb5808657592eb36e76d1ed53c4d82e"
     }
   }
 }

--- a/tooling/stryker/stryker.config.mjs
+++ b/tooling/stryker/stryker.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 
+import { globSync } from "node:fs";
 import { strykerBase } from "./stryker-base.config.mjs";
 
 // Full-suite mutation testing — mutates ALL source files.
@@ -8,18 +9,41 @@ import { strykerBase } from "./stryker-base.config.mjs";
 // Or from repo root:
 //   bun run test:mutants
 //
-// When STRYKER_SHARD=a or =b is set, the mutate set is sharded
-// alphabetically by source filename (a–m and n–z). Each shard runs
-// independently with its own incremental cache key in CI, halving the
-// wall-clock for the daily mutation-test workflow. Unset (or any other
-// value) → full suite, identical to the historical behaviour.
+// When STRYKER_SHARD=a|b|c|d is set, the mutate set is sharded into N
+// balanced parts by round-robin over the *sorted* source-file list. Each
+// shard runs independently with its own incremental cache key in CI.
+//
+// Why round-robin instead of the old alphabetic a–m / n–z buckets: Stryker
+// wall-clock is dominated by how slow the tests covering a mutated file are
+// (perTest + vitest `related:true`), NOT by file count or LOC. The handful
+// of source files whose mutants drag in the network-bound integration-verify
+// suite (120s timeoutMS × retries) and the heavy SQLite-migration tests all
+// happened to sort into the a–m bucket, so shard "a" ran cold for 6h+ and
+// was killed by GitHub's hard 6-hour per-job ceiling — before it could push
+// its refreshed incremental cache, leaving the next run just as cold (a doom
+// loop that surfaced as a recurring "cancelled" Mutation Testing run on main).
+// Round-robin interleaves those expensive files across every shard, and N=4
+// keeps even a fully-cold shard well under the 6h ceiling. Unset (or any
+// other value) → full suite, identical to the historical behaviour.
+const SHARD_NAMES = ["a", "b", "c", "d"];
 const SHARD = process.env.STRYKER_SHARD ?? "";
-const shardFilters =
-	SHARD === "a"
-		? ["!src/[n-zN-Z]*.ts", "!src/[n-zN-Z]*/**/*.ts"]
-		: SHARD === "b"
-			? ["!src/[a-mA-M]*.ts", "!src/[a-mA-M]*/**/*.ts"]
-			: [];
+const shardIndex = SHARD_NAMES.indexOf(SHARD);
+let shardFilters = [];
+if (shardIndex >= 0) {
+	const shardCount = SHARD_NAMES.length;
+	// globSync runs with cwd = the Stryker project root (packages/astropress),
+	// so paths come back as "src/…", matching the mutate base glob below.
+	// Sort for a stable, host-independent assignment; exclude every file that
+	// does not belong to this shard. The data-only / barrel exclusions below
+	// still apply on top, so a file assigned to this shard that is also a
+	// global exclusion stays excluded everywhere (no double-mutation).
+	const allSources = globSync("src/**/*.ts")
+		.filter((file) => !file.endsWith(".d.ts"))
+		.sort();
+	shardFilters = allSources
+		.filter((_file, index) => index % shardCount !== shardIndex)
+		.map((file) => `!${file}`);
+}
 
 export default {
 	...strykerBase,


### PR DESCRIPTION
## Summary

Two things in one PR (solo maintainer, single-PR workflow):

### 1. Fix the recurring main-CI failure — Mutation Testing "cancelled"
The `Mutation Testing` workflow has been repeatedly **cancelled** on `main` (05-16, 05-18, 05-19). Root cause: Stryker shard **a** hit GitHub's **hard 6-hour per-job ceiling**.

Mutation wall-clock is driven by how slow the *tests covering* a mutated file are (`perTest` + vitest `related:true`), **not** file count — shard b (n–z, *more* LOC) finished in 18m while shard a ran 6h+. The files whose mutants pull in the network-bound integration-verify suite (120s `timeoutMS` × retries) and heavy SQLite-migration tests all sorted into the a–m bucket. A 6h hard-cap kill is reported as `cancelled` (not a step failure) and **cannot be absorbed by `continue-on-error`**; worse, the job died before pushing its refreshed incremental cache, so the next run started cold too — a doom loop.

Fix:
- **`stryker.config.mjs`**: replace the alphabetic a–m / n–z buckets with a balanced **N-way round-robin over the sorted source-file list**. Verified locally: 80/80/80/80 files, disjoint + complete, heavy files spread evenly (32/36/36/35). N=4 keeps even a fully-cold shard ~1–1.5h, far under the ceiling.
- **`mutation-test.yml`**: matrix `shard: [a, b, c, d]`; drop the impossible `timeout-minutes: 480` (8h could never apply) to **330**.

### 2. Issue #141 — webhook REST API validation parity
The token-authenticated REST create path (`pages/ap-api/v1/webhooks.ts`) only checked `url` non-empty + `events` non-empty, so a `webhooks:manage` token could persist arbitrary callback targets / event names the admin UI rejects — and the dispatcher later `fetch()`es the stored URL.

- New **shared validator** `src/webhook-validation.ts` (+ data-only allowlist sibling) enforces the `http(s)` scheme and the canonical event allowlist. Unsupported events are **rejected, not silently dropped**; the error lists supported events rather than echoing attacker-controlled input.
- Both the admin action and the REST endpoint now delegate to this one layer, so they cannot drift.
- Tests: exhaustive validator units, REST rejection (422, no persist), admin-action parity. Mutation baseline recorded at 96.08%.

### 3. Dependency security
- Override `qs` → `^6.15.2` to clear **GHSA-q8mj-m7cp-5q26** (moderate DoS, newly published; transitive via `@modelcontextprotocol/sdk` and `@stryker-mutator/core`).

Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)