### PR TITLE
fix(#134, #28, supersedes #37): subscriber-delete CSRF test + import-source request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/import_source_request.md
+++ b/.github/ISSUE_TEMPLATE/import_source_request.md
@@ -1,0 +1,57 @@
+---
+name: Import source request (migrate from a platform)
+about: Request a new migration source — CMS, site builder, or subscriber-list export
+title: "[Import] "
+labels: import, enhancement
+assignees: ""
+---
+
+> **Not a migration source?** For new *hosting providers or data services* (Cloudflare, Turso, Neon, S3…) use the [adapter request](?template=adapter_support.md). For new *external tools* (analytics, email, donations) use the [integration request](?template=integration_request.md). For new *locales* use the [language request](?template=language_request.md).
+
+## Source platform details
+
+| Field | Value |
+|-------|-------|
+| Source platform name | <!-- e.g. Drupal, Joomla, Squarespace, Ghost, Substack --> |
+| Source kind | <!-- CMS / site builder / subscriber list / static-site generator --> |
+| Export format the source produces | <!-- XML / JSON / CSV / ZIP / live HTTP crawl / DB dump --> |
+| Public docs for the export | <!-- link to the source's export/format docs --> |
+
+## What does the source let an operator export?
+
+Tick all that apply:
+
+- [ ] **Pages and posts** (HTML or Markdown body, title, slug, status)
+- [ ] **Media files** (images, attachments, with original URLs)
+- [ ] **Taxonomies** (categories, tags)
+- [ ] **Authors / users**
+- [ ] **Comments**
+- [ ] **Redirects** (legacy URLs → new paths)
+- [ ] **Subscriber lists** (email + status, like the Mailchimp importer)
+- [ ] **Other**: ___
+
+## Why this source?
+
+One paragraph: which users get unblocked by this importer? Linking a public site that already runs on the source platform helps maintainers gauge scope.
+
+## Proposed stage-then-apply shape
+
+Astropress importers stage migrations into a reviewable artifact before applying them locally (see `packages/astropress/src/import/` — the WordPress XML and Wix CSV importers are the precedents). Sketch which stage helpers and apply helpers this source would need:
+
+- Fetch / parse: ___
+- Stage artifact (`*-import-staged.json`): ___
+- Apply helper (writes into the local content store): ___
+- Media download path (must go through `downloadMediaToFile()` from `packages/astropress/src/import/download-media.ts` for SSRF + content-type + size enforcement)
+
+## Can you help implement it?
+
+- [ ] Yes — I can submit a PR including a recording fixture of the source's export.
+- [ ] Partial — I can supply a real export from a site I own as a fixture.
+- [ ] No — I am requesting only.
+
+## Pointers
+
+- `packages/astropress/src/import/wordpress-xml.ts` — XML-export precedent
+- `packages/astropress/src/import/wix-csv.ts` — CSV / multi-file-export precedent
+- `packages/astropress/src/import/download-media.ts` — required for any HTTP media fetch
+- [CONTRIBUTING.md → Requesting and contributing providers](../../CONTRIBUTING.md#requesting-and-contributing-providers)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ Run `bun run bdd:lint` to validate feature file syntax.
 
 ## Requesting and contributing providers
 
-Astropress supports three kinds of plug-in points, each with a different intake template and a different audit gate.
+Astropress supports four kinds of plug-in points, each with a different intake template and a different audit gate.
 
 ### Hosting providers and data services (adapters)
 
@@ -149,6 +149,17 @@ Workflow:
 3. If the provider uses OAuth 2.0 authorization-code, also wire it through `pages/ap-admin/oauth/callback/[provider].ts`; tokens must seal into `integration_secrets` via the existing helper.
 4. Update `docs/reference/integrations.md` with a one-paragraph entry and a link to the provider's docs.
 5. Open a PR; CI exercises the registry + secret-store gates automatically.
+
+### Import sources (migrating from another CMS, site builder, or subscriber export)
+
+These plug in under `packages/astropress/src/import/` and follow a stage-then-apply shape: a fetcher/parser writes a reviewable JSON artifact, and an apply helper merges it into the local content store. The WordPress XML, Wix CSV, and Mailchimp subscriber-list importers are the existing precedents. HTTP media fetches must go through `downloadMediaToFile()` for SSRF, content-type, and size enforcement.
+
+Workflow:
+1. File an [Import source request](.github/ISSUE_TEMPLATE/import_source_request.md) issue with the source platform, export format, and an example fixture you can share.
+2. Add `fetch-<source>.ts` and/or `<source>-xml.ts` / `<source>-csv.ts` next to the existing importers. Stage output into `*-import-staged.json` rather than mutating the store directly.
+3. Add an `<source>-apply.ts` helper that consumes the staged artifact. Use `downloadMediaToFile()` for any remote media.
+4. Add a recording fixture under `packages/astropress/tests/fixtures/` and a vitest covering the parser, the staged shape, and the apply step.
+5. Open a PR; CI exercises the importer against the fixture.
 
 ### New admin or content languages (locales)
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Importing content from Wordpress or Wix, or even subscription lists from Mailchi
 
 ### Requesting new platforms, integrations, or languages
 
-Five places to open an issue, picked by what you need:
+Six places to open an issue, picked by what you need:
 
 | You want… | Open this template |
 |-----------|--------------------|
 | A **new hosting provider** or **data service** (Cloudflare, Turso, Neon, Vercel, S3-compatible storage…) | [Adapter request](../../issues/new?template=adapter_support.md) |
 | A **new external tool** (analytics, email, A/B testing, donations, webhooks…) | [Integration request](../../issues/new?template=integration_request.md) |
+| **To migrate from a source platform** (CMS, site builder, subscriber export — Drupal, Squarespace, Ghost, Substack…) | [Import source request](../../issues/new?template=import_source_request.md) |
 | A **new admin or content language** (locale) | [Language request](../../issues/new?template=language_request.md) |
 | A **new framework capability** (not tied to a specific provider) | [Feature request](../../issues/new?template=feature_request.md) |
 | Something is **broken** | [Bug report](../../issues/new?template=bug_report.md) |

--- a/packages/astropress/tests/admin-confirm-dialogs.test.ts
+++ b/packages/astropress/tests/admin-confirm-dialogs.test.ts
@@ -61,4 +61,24 @@ describe("destructive actions use confirm dialogs", () => {
 		expect(src).toContain("ap-confirm-dialog");
 		expect(src).toContain('id="confirm-delete-subscriber"');
 	});
+
+	// Issue #134: the subscriber-delete action runs through withAdminFormAction,
+	// which rejects requests without a CSRF token. The confirm-dialog form on the
+	// detail page is the only call site that can submit it, so verify the modal's
+	// <form> itself carries a CsrfInput — not just that the sweeping audit passes.
+	it("subscriber detail delete modal form includes a CSRF token (issue #134)", () => {
+		const src = readFileSync(path.join(adminPagesRoot, "subscribers", "[id].astro"), "utf8");
+		// Isolate the <form> that posts to subscriber-delete so the assertion can't
+		// be satisfied by an unrelated CsrfInput elsewhere on the page.
+		const formMatch = src.match(
+			/<form\b[^>]*action=["']\/ap-admin\/actions\/subscriber-delete["'][^>]*>([\s\S]*?)<\/form>/,
+		);
+		expect(
+			formMatch,
+			"expected a <form> posting to /ap-admin/actions/subscriber-delete",
+		).not.toBeNull();
+		const formBody = formMatch?.[1] ?? "";
+		expect(formBody).toMatch(/<CsrfInput\b[^/]*token=\{Astro\.locals\.csrfToken\}/);
+		expect(formBody).toContain('name="id"');
+	});
 });


### PR DESCRIPTION
## Summary

Closes #134, closes #37 (by superseding without taking the PR's redundant code), continues #28 follow-up by filling a real gap in the platform-request intake surface.

### Issue #134 — subscriber-delete CSRF coverage

The destructive subscriber-delete modal form on \`pages/ap-admin/subscribers/[id].astro\` already renders \`<CsrfInput token={Astro.locals.csrfToken} />\` (added in the #146 sweep), and the sweeping audit in \`admin-routes-auth-matrix.test.ts\` would catch a regression. What was still missing — and what #134 explicitly asks for — is a **focused test against the modal path** so a regression in this confirm-dialog form can't slip through behind an unrelated file-level CsrfInput.

New test in \`packages/astropress/tests/admin-confirm-dialogs.test.ts\` isolates the \`<form action="/ap-admin/actions/subscriber-delete">\` block, asserts a \`CsrfInput\` with \`token={Astro.locals.csrfToken}\` is inside that form body, and asserts the hidden \`id\` input is preserved. The action wrapper test stays as the integration-level guarantee.

### Superseding PR #37

PR #37 added four \"Request: …\" rows to the \"Supported categories and tools\" table. That table documents shipping categories with verified providers; mixing request-channel rows into it confuses the supported-vs-aspirational distinction the registry/audit gates protect. The repo already has a dedicated \"Requesting new platforms, integrations, or languages\" section in the README (added under #28) with a clean template chooser. So PR #37's additions are redundant where it overlaps the existing section, and incorrect where it tries to repurpose the supported-tools table for intake.

But #37 was nudging at a real underlying gap: there was no intake path for users who want to migrate **from** a new source platform (CMS, site builder, subscriber export). The Mailchimp / Wix / WordPress importers are the precedent, but a Drupal / Squarespace / Ghost / Substack user had nowhere obvious to file. This PR fixes that intake gap instead of taking #37's table additions.

### Changes

- **\`.github/ISSUE_TEMPLATE/import_source_request.md\`** — new template mirroring the \`adapter_support\` / \`integration_request\` structure. Calls out the stage-then-apply shape, requires \`downloadMediaToFile()\` for HTTP media (SSRF + content-type + size enforcement), and links the existing \`wordpress-xml.ts\` / \`wix-csv.ts\` precedents.
- **\`README.md\`** — \"Requesting new platforms\" table grows 5 → 6 rows; adds the import-source row between integrations and locales.
- **\`CONTRIBUTING.md\`** — \"Requesting and contributing providers\" grows 3 → 4 plug-in points; adds an \"Import sources\" subsection with the staging-artifact workflow.
- **\`packages/astropress/tests/admin-confirm-dialogs.test.ts\`** — focused regression test described above.

### Verification

- \`bun run vitest run packages/astropress/tests/admin-confirm-dialogs.test.ts\` — 8 passed (was 7)
- \`bun run vitest run packages/astropress/tests/admin-routes-auth-matrix.test.ts\` — 9 passed (sweeping CSRF audit still green)
- pre-push gate (~11.6m, all green): no-secrets, verify-signing, audit-developer-ergonomics, audit-oss-health, audit-doc-links, audit-followup-marker, audit-test-fanout, audit-arch, audit-microcopy, audit-suppressions, biome, audit-codeql-patterns, audit-honesty, stryker-contamination, audit-suppression-warnings, mutation-gate, slow-audits
- post-push: will run \`bun run check:pr-ghas\` once the CodeQL scan on the PR merge ref completes

Closes #134
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)