### PR TITLE
fix(#159): redirect Git Bash / MINGW users to install.ps1

### DIFF
--- a/tooling/scripts/install.sh
+++ b/tooling/scripts/install.sh
@@ -41,6 +41,18 @@ case "$OS" in
   FreeBSD) PLATFORM="freebsd" ;;
   OpenBSD) PLATFORM="openbsd" ;;
   NetBSD)  PLATFORM="netbsd"  ;;
+  MINGW*|MSYS*|CYGWIN*)
+    echo ""
+    echo "  install.sh does not support Git Bash / MINGW / MSYS on Windows."
+    echo "  Please use the PowerShell installer instead:"
+    echo ""
+    echo "    pwsh tooling/scripts/install.ps1"
+    echo ""
+    echo "  If you do not have PowerShell 7+, install it from:"
+    echo "    https://aka.ms/powershell"
+    echo ""
+    exit 1
+    ;;
   *)       die "Unsupported OS: $OS. Use the devcontainer or install manually." ;;
 esac
 info "Platform: $PLATFORM ($ARCH)"


### PR DESCRIPTION
## Summary

`install.sh` previously hit the generic `die "Unsupported OS"` path when run from Git Bash / MINGW64 / MSYS2 on Windows, giving no actionable guidance.

This PR detects the `MINGW*`, `MSYS*`, and `CYGWIN*` `uname -s` prefixes and exits with a clear redirect message:

```
  install.sh does not support Git Bash / MINGW / MSYS on Windows.
  Please use the PowerShell installer instead:

    pwsh tooling/scripts/install.ps1

  If you do not have PowerShell 7+, install it from:
    https://aka.ms/powershell
```

`install.sh` cannot support MINGW/MSYS because Windows-native tools (cargo, PowerShell cmdlets) don't behave correctly under POSIX emulation layers. The redirect to `install.ps1` is the correct supported path.

## Test plan

- [ ] On Linux/macOS: `bash tooling/scripts/install.sh` still works normally
- [ ] Simulate Git Bash: `OS=MINGW64_NT-10.0-26200 bash -c 'uname() { echo "$OS"; }; source tooling/scripts/install.sh'` → prints redirect message and exits 1 (or manually verify the case block)
- [ ] `bun run audit:installer-scripts` passes

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hvs3hu3eb39Ghsg1v2rZA8