### PR TITLE
test(#159): guard MINGW redirect in audit-installer-scripts

### DIFF
--- a/tooling/scripts/audit-installer-scripts.ts
+++ b/tooling/scripts/audit-installer-scripts.ts
@@ -6,6 +6,8 @@
  *      would fail when there is no Cargo.toml at the repo root).
  *   2. Use `bun x playwright` instead of `npx … playwright` so the lockfile-
  *      pinned browser revision is used and npm is never invoked in a Bun repo.
+ *   3. install.sh handles MINGW/MSYS/CYGWIN uname prefixes with a redirect to
+ *      install.ps1 rather than a generic die or silent fall-through (#159).
  *
  * Also checks that package.json does not carry an `overrides.astro` value that
  * contradicts the direct `dependencies.astro` entry (npm EOVERRIDE).
@@ -93,13 +95,48 @@ async function checkPackageJsonOverrides(report: AuditReport): Promise<void> {
 	}
 }
 
+async function checkMingwRedirect(report: AuditReport): Promise<void> {
+	const shPath = fromRoot("tooling/scripts/install.sh");
+	let src: string;
+	try {
+		src = await readFile(shPath, "utf8");
+	} catch {
+		report.add(`${shPath}: file not found`);
+		return;
+	}
+
+	// install.sh must have a case arm matching MINGW*/MSYS*/CYGWIN* that
+	// redirects to install.ps1 rather than hitting the generic die or
+	// falling through to POSIX-only code that will not work on Windows.
+	const hasMingwArm =
+		/MINGW\*\|MSYS\*\|CYGWIN\*/.test(src) ||
+		/MINGW\*[^)]*\|[^)]*MSYS\*[^)]*\|[^)]*CYGWIN\*/.test(src);
+	if (!hasMingwArm) {
+		report.add(
+			`${shPath}: no MINGW*/MSYS*/CYGWIN* case arm found — ` +
+				`Git Bash users on Windows will hit the generic die with no actionable guidance (see #159)`,
+		);
+		return;
+	}
+
+	if (!src.includes("install.ps1")) {
+		report.add(
+			`${shPath}: MINGW/MSYS/CYGWIN arm does not reference install.ps1 — ` +
+				`the redirect message must tell users which script to run instead`,
+		);
+	}
+}
+
 runAudit("installer-scripts", async () => {
 	const report = new AuditReport("installer-scripts");
 
 	await Promise.all([
 		...INSTALL_SCRIPTS.map((s) => checkScript(s, report)),
 		checkPackageJsonOverrides(report),
+		checkMingwRedirect(report),
 	]);
 
-	report.finish("installer-scripts audit passed — no bare cargo calls, no npx playwright, no override conflicts");
+	report.finish(
+		"installer-scripts audit passed — no bare cargo calls, no npx playwright, no override conflicts, MINGW redirect present",
+	);
 });


### PR DESCRIPTION
## Summary

The MINGW redirect fix from #167 landed without its regression guard — the second commit failed to push because the branch was deleted by the merge before the pre-push hook finished.

This PR adds `checkMingwRedirect()` to `audit-installer-scripts.ts`, which runs as part of the `audit:installer-scripts` pre-push gate. It enforces:

1. `install.sh` has a `MINGW*|MSYS*|CYGWIN*` case arm (prevents regressing to the generic `die`)
2. That arm references `install.ps1` (ensures the redirect message is actionable)

## Test plan

- [ ] `bun run audit:installer-scripts` passes with the arm in place
- [ ] Removing the `MINGW*|MSYS*|CYGWIN*)` block from `install.sh` causes the audit to fail

Closes #159 (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hvs3hu3eb39Ghsg1v2rZA8